### PR TITLE
feat: add authenticated access with per-user storage

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,5 +1,13 @@
-(function () {
-  const STORAGE_KEY = 'umanager-data-store';
+(async function () {
+  const USER_STORE_KEY = 'umanager-user-store';
+  const ACTIVE_USER_KEY = 'umanager-active-user';
+  const DATA_KEY_PREFIX = 'umanager-data-store:';
+  const DEFAULT_ADMINS = [
+    { username: 'admin1', password: 'emsal1', email: 'admin1@umanager.local' },
+    { username: 'admin2', password: 'emsal2', email: 'admin2@umanager.local' },
+    { username: 'admin3', password: 'emsal3', email: 'admin3@umanager.local' },
+  ];
+
   const defaultData = {
     metrics: {
       peopleCount: 0,
@@ -9,6 +17,19 @@
     keywords: [],
     lastUpdated: null,
   };
+
+  const authView = document.getElementById('auth-view');
+  const loginSection = document.getElementById('login-section');
+  const registerSection = document.getElementById('register-section');
+  const loginForm = document.getElementById('login-form');
+  const registerForm = document.getElementById('register-form');
+  const loginError = document.getElementById('login-error');
+  const registerError = document.getElementById('register-error');
+  const showRegisterBtn = document.getElementById('show-register');
+  const showLoginBtn = document.getElementById('show-login');
+  const appContainer = document.querySelector('.app');
+  const currentUsernameEl = document.getElementById('current-username');
+  const logoutButton = document.getElementById('logout-button');
 
   const pages = document.querySelectorAll('.page');
   const navButtons = document.querySelectorAll('.nav-button');
@@ -23,127 +44,416 @@
   const keywordEmptyState = document.getElementById('keyword-empty-state');
   const keywordTemplate = document.getElementById('keyword-item-template');
 
-  let data = loadData();
-  renderNavigation();
-  renderMetrics();
-  renderKeywords();
+  let currentUser = null;
+  let data = null;
+  let appHandlersInitialized = false;
 
-  function loadData() {
-    try {
-      const stored = window.localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        return {
-          metrics: { ...defaultData.metrics, ...(parsed.metrics || {}) },
-          keywords: Array.isArray(parsed.keywords) ? parsed.keywords : [],
-          lastUpdated: parsed.lastUpdated || null,
+  await ensureDefaultAdmins();
+  initializeAuth();
+  initializeAppHandlers();
+
+  const storedActiveUser = loadActiveUser();
+  const userStore = loadUserStore();
+  if (storedActiveUser && userStore.users[storedActiveUser]) {
+    await activateUser(storedActiveUser);
+  } else {
+    showLoginView();
+  }
+
+  async function ensureDefaultAdmins() {
+    const store = loadUserStore();
+    let updated = false;
+
+    for (const admin of DEFAULT_ADMINS) {
+      if (!store.users[admin.username]) {
+        const passwordHash = await hashPassword(admin.password);
+        store.users[admin.username] = {
+          email: admin.email,
+          passwordHash,
         };
+        updated = true;
       }
-    } catch (error) {
-      console.warn('Impossible de charger les données locales :', error);
     }
-    return JSON.parse(JSON.stringify(defaultData));
-  }
 
-  function saveData() {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-    } catch (error) {
-      console.warn('Impossible de sauvegarder les données locales :', error);
+    if (updated) {
+      saveUserStore(store);
     }
   }
 
-  function renderNavigation() {
+  function initializeAuth() {
+    if (showRegisterBtn) {
+      showRegisterBtn.addEventListener('click', () => {
+        if (registerError) {
+          registerError.textContent = '';
+        }
+        if (loginError) {
+          loginError.textContent = '';
+        }
+        showRegisterView();
+      });
+    }
+
+    if (showLoginBtn) {
+      showLoginBtn.addEventListener('click', () => {
+        if (registerError) {
+          registerError.textContent = '';
+        }
+        if (loginError) {
+          loginError.textContent = '';
+        }
+        showLoginView();
+      });
+    }
+
+    if (logoutButton) {
+      logoutButton.addEventListener('click', () => {
+        currentUser = null;
+        data = null;
+        clearActiveUser();
+        if (currentUsernameEl) {
+          currentUsernameEl.textContent = '—';
+        }
+        if (appContainer) {
+          appContainer.hidden = true;
+        }
+        showLoginView();
+        if (loginForm) {
+          loginForm.reset();
+        }
+        if (registerForm) {
+          registerForm.reset();
+        }
+        if (loginError) {
+          loginError.textContent = '';
+        }
+        if (registerError) {
+          registerError.textContent = '';
+        }
+      });
+    }
+
+    if (loginForm) {
+      loginForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (loginError) {
+          loginError.textContent = '';
+        }
+
+        const formData = new FormData(loginForm);
+        const username = (formData.get('username') || '').toString().trim();
+        const password = (formData.get('password') || '').toString();
+
+        if (!username || !password) {
+          if (loginError) {
+            loginError.textContent = 'Veuillez renseigner vos identifiants.';
+          }
+          return;
+        }
+
+        const store = loadUserStore();
+        const user = store.users[username];
+        if (!user) {
+          if (loginError) {
+            loginError.textContent = 'Identifiant ou mot de passe invalide.';
+          }
+          return;
+        }
+
+        const passwordHash = await hashPassword(password);
+        if (passwordHash !== user.passwordHash) {
+          if (loginError) {
+            loginError.textContent = 'Identifiant ou mot de passe invalide.';
+          }
+          return;
+        }
+
+        loginForm.reset();
+        await activateUser(username);
+      });
+    }
+
+    if (registerForm) {
+      registerForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (registerError) {
+          registerError.textContent = '';
+        }
+
+        const formData = new FormData(registerForm);
+        const username = (formData.get('username') || '').toString().trim();
+        const email = (formData.get('email') || '').toString().trim();
+        const password = (formData.get('password') || '').toString();
+        const confirmPassword = (formData.get('password-confirm') || '')
+          .toString();
+
+        if (!username || !email || !password || !confirmPassword) {
+          if (registerError) {
+            registerError.textContent = 'Tous les champs sont obligatoires.';
+          }
+          return;
+        }
+
+        if (!isValidEmail(email)) {
+          if (registerError) {
+            registerError.textContent = 'Veuillez saisir une adresse mail valide.';
+          }
+          return;
+        }
+
+        if (password.length < 6) {
+          if (registerError) {
+            registerError.textContent =
+              'Le mot de passe doit contenir au moins 6 caractères.';
+          }
+          return;
+        }
+
+        if (password !== confirmPassword) {
+          if (registerError) {
+            registerError.textContent =
+              'La confirmation du mot de passe ne correspond pas.';
+          }
+          return;
+        }
+
+        const store = loadUserStore();
+        if (store.users[username]) {
+          if (registerError) {
+            registerError.textContent = 'Cet identifiant est déjà utilisé.';
+          }
+          return;
+        }
+
+        const emailExists = Object.values(store.users).some((user) => {
+          if (!user.email) {
+            return false;
+          }
+          return user.email.toLowerCase() === email.toLowerCase();
+        });
+
+        if (emailExists) {
+          if (registerError) {
+            registerError.textContent =
+              'Cette adresse mail est déjà associée à un compte.';
+          }
+          return;
+        }
+
+        const passwordHash = await hashPassword(password);
+        store.users[username] = {
+          email,
+          passwordHash,
+        };
+        saveUserStore(store);
+        registerForm.reset();
+        await activateUser(username);
+      });
+    }
+  }
+
+  function initializeAppHandlers() {
+    if (appHandlersInitialized) {
+      return;
+    }
+    appHandlersInitialized = true;
+
     navButtons.forEach((button) => {
       button.addEventListener('click', () => {
         const target = button.dataset.target;
-        if (!target) return;
-
-        navButtons.forEach((btn) => btn.classList.toggle('active', btn === button));
-        pages.forEach((page) => page.classList.toggle('active', page.id === target));
+        if (!target) {
+          return;
+        }
+        showPage(target);
       });
+    });
+
+    metricForms.forEach((form) => {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        if (!currentUser || !data) {
+          return;
+        }
+        const key = form.dataset.form;
+        if (!key) {
+          return;
+        }
+        const input = form.querySelector('[data-input]');
+        const value = Number.parseInt(input.value, 10);
+
+        if (Number.isNaN(value) || value < 0) {
+          input.setCustomValidity('Veuillez renseigner un nombre positif.');
+          input.reportValidity();
+          return;
+        }
+
+        input.setCustomValidity('');
+        data.metrics[key] = value;
+        data.lastUpdated = new Date().toISOString();
+        saveData();
+        renderMetrics();
+        input.value = '';
+      });
+    });
+
+    if (keywordForm) {
+      keywordForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        if (!currentUser || !data) {
+          return;
+        }
+        const formData = new FormData(keywordForm);
+        const name = (formData.get('keyword-name') || '').toString().trim();
+        const description = (formData.get('keyword-description') || '')
+          .toString()
+          .trim();
+
+        if (!name) {
+          return;
+        }
+
+        const keyword = {
+          id: generateId(),
+          name,
+          description,
+        };
+
+        data.keywords.push(keyword);
+        data.lastUpdated = new Date().toISOString();
+        saveData();
+        keywordForm.reset();
+        const keywordNameInput = keywordForm.querySelector('#keyword-name');
+        if (keywordNameInput) {
+          keywordNameInput.focus();
+        }
+        renderMetrics();
+        renderKeywords();
+      });
+    }
+  }
+
+  async function activateUser(username) {
+    currentUser = username;
+    data = loadData();
+    saveActiveUser(username);
+    updateSidebarUser();
+    if (loginError) {
+      loginError.textContent = '';
+    }
+    if (registerError) {
+      registerError.textContent = '';
+    }
+    if (authView) {
+      authView.hidden = true;
+    }
+    if (appContainer) {
+      appContainer.hidden = false;
+    }
+    showPage('dashboard');
+    renderMetrics();
+    renderKeywords();
+  }
+
+  function showLoginView() {
+    if (authView) {
+      authView.hidden = false;
+    }
+    if (loginSection) {
+      loginSection.hidden = false;
+    }
+    if (registerSection) {
+      registerSection.hidden = true;
+    }
+    if (loginError) {
+      loginError.textContent = '';
+    }
+    window.requestAnimationFrame(() => {
+      const usernameInput = document.getElementById('login-username');
+      if (usernameInput) {
+        usernameInput.focus();
+      }
+    });
+  }
+
+  function showRegisterView() {
+    if (loginSection) {
+      loginSection.hidden = true;
+    }
+    if (registerSection) {
+      registerSection.hidden = false;
+    }
+    if (registerError) {
+      registerError.textContent = '';
+    }
+    window.requestAnimationFrame(() => {
+      const usernameInput = document.getElementById('register-username');
+      if (usernameInput) {
+        usernameInput.focus();
+      }
     });
   }
 
   function renderMetrics() {
+    if (!data) {
+      metricValues.forEach((metricValue) => {
+        metricValue.textContent = '0';
+      });
+      if (totalDatasetsEl) {
+        totalDatasetsEl.textContent = '0';
+      }
+      if (keywordCountEl) {
+        keywordCountEl.textContent = '0';
+      }
+      if (keywordsActiveCountEl) {
+        keywordsActiveCountEl.textContent = '0';
+      }
+      if (lastUpdatedEl) {
+        lastUpdatedEl.textContent = '—';
+      }
+      return;
+    }
+
     metricValues.forEach((metricValue) => {
       const key = metricValue.dataset.metric;
-      if (!key) return;
+      if (!key) {
+        return;
+      }
       const value = Number(data.metrics[key]) || 0;
       metricValue.textContent = new Intl.NumberFormat('fr-FR').format(value);
     });
 
-    totalDatasetsEl.textContent = new Intl.NumberFormat('fr-FR').format(
-      data.metrics.peopleCount + data.metrics.phoneCount + data.metrics.emailCount,
-    );
+    if (totalDatasetsEl) {
+      totalDatasetsEl.textContent = new Intl.NumberFormat('fr-FR').format(
+        data.metrics.peopleCount + data.metrics.phoneCount + data.metrics.emailCount,
+      );
+    }
 
-    keywordCountEl.textContent = data.keywords.length.toString();
-    keywordsActiveCountEl.textContent = data.keywords.length.toString();
+    if (keywordCountEl) {
+      keywordCountEl.textContent = data.keywords.length.toString();
+    }
 
-    if (data.lastUpdated) {
+    if (keywordsActiveCountEl) {
+      keywordsActiveCountEl.textContent = data.keywords.length.toString();
+    }
+
+    if (data.lastUpdated && lastUpdatedEl) {
       const formatted = new Intl.DateTimeFormat('fr-FR', {
         dateStyle: 'medium',
         timeStyle: 'short',
       }).format(new Date(data.lastUpdated));
       lastUpdatedEl.textContent = formatted;
-    } else {
+    } else if (lastUpdatedEl) {
       lastUpdatedEl.textContent = '—';
     }
   }
 
-  metricForms.forEach((form) => {
-    form.addEventListener('submit', (event) => {
-      event.preventDefault();
-      const key = form.dataset.form;
-      if (!key) return;
-      const input = form.querySelector('[data-input]');
-      const value = Number.parseInt(input.value, 10);
-
-      if (Number.isNaN(value) || value < 0) {
-        input.setCustomValidity('Veuillez renseigner un nombre positif.');
-        input.reportValidity();
-        return;
-      }
-
-      input.setCustomValidity('');
-      data.metrics[key] = value;
-      data.lastUpdated = new Date().toISOString();
-      saveData();
-      renderMetrics();
-      input.value = '';
-    });
-  });
-
-  keywordForm.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const formData = new FormData(keywordForm);
-    const name = formData.get('keyword-name').trim();
-    const description = formData.get('keyword-description').trim();
-
-    if (!name) {
+  function renderKeywords() {
+    if (!keywordList || !keywordEmptyState || !keywordTemplate) {
       return;
     }
 
-    const keyword = {
-      id: generateId(),
-      name,
-      description,
-      createdAt: new Date().toISOString(),
-    };
-
-    data.keywords.push(keyword);
-    data.lastUpdated = new Date().toISOString();
-    saveData();
-    keywordForm.reset();
-    keywordForm.querySelector('#keyword-name').focus();
-    renderMetrics();
-    renderKeywords();
-  });
-
-  function renderKeywords() {
     keywordList.innerHTML = '';
 
-    if (data.keywords.length === 0) {
+    if (!data || data.keywords.length === 0) {
       keywordEmptyState.hidden = false;
       return;
     }
@@ -160,7 +470,10 @@
         const descriptionEl = item.querySelector('.keyword-description');
         titleEl.textContent = keyword.name;
         descriptionEl.textContent = keyword.description || 'Aucune description renseignée.';
-        descriptionEl.classList.toggle('keyword-description--empty', !keyword.description);
+        descriptionEl.classList.toggle(
+          'keyword-description--empty',
+          !keyword.description,
+        );
 
         item.querySelector('[data-action="edit"]').addEventListener('click', () => {
           startKeywordEdition(keyword.id);
@@ -175,11 +488,18 @@
   }
 
   function startKeywordEdition(keywordId) {
+    if (!data) {
+      return;
+    }
     const keyword = data.keywords.find((item) => item.id === keywordId);
-    if (!keyword) return;
+    if (!keyword) {
+      return;
+    }
 
     const listItem = keywordList.querySelector(`[data-id="${keywordId}"]`);
-    if (!listItem) return;
+    if (!listItem) {
+      return;
+    }
 
     listItem.classList.add('editing');
     listItem.innerHTML = '';
@@ -207,9 +527,12 @@
 
     form.addEventListener('submit', (event) => {
       event.preventDefault();
+      if (!data) {
+        return;
+      }
       const formData = new FormData(form);
-      const name = formData.get('name').trim();
-      const description = formData.get('description').trim();
+      const name = (formData.get('name') || '').toString().trim();
+      const description = (formData.get('description') || '').toString().trim();
 
       if (!name) {
         return;
@@ -229,16 +552,144 @@
 
     listItem.appendChild(form);
     const nameInput = form.querySelector('input[name="name"]');
-    nameInput.focus();
-    nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
+    if (nameInput) {
+      nameInput.focus();
+      nameInput.setSelectionRange(nameInput.value.length, nameInput.value.length);
+    }
   }
 
   function deleteKeyword(keywordId) {
+    if (!data) {
+      return;
+    }
     data.keywords = data.keywords.filter((item) => item.id !== keywordId);
     data.lastUpdated = new Date().toISOString();
     saveData();
     renderMetrics();
     renderKeywords();
+  }
+
+  function showPage(target) {
+    navButtons.forEach((button) => {
+      button.classList.toggle('active', button.dataset.target === target);
+    });
+    pages.forEach((page) => {
+      page.classList.toggle('active', page.id === target);
+    });
+  }
+
+  function updateSidebarUser() {
+    if (currentUsernameEl) {
+      currentUsernameEl.textContent = currentUser || '—';
+    }
+  }
+
+  function loadData() {
+    if (!currentUser) {
+      return cloneDefaultData();
+    }
+
+    const storageKey = `${DATA_KEY_PREFIX}${currentUser}`;
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return {
+          metrics: { ...defaultData.metrics, ...(parsed.metrics || {}) },
+          keywords: Array.isArray(parsed.keywords) ? parsed.keywords : [],
+          lastUpdated: parsed.lastUpdated || null,
+        };
+      }
+    } catch (error) {
+      console.warn('Impossible de charger les données locales :', error);
+    }
+
+    return cloneDefaultData();
+  }
+
+  function saveData() {
+    if (!currentUser || !data) {
+      return;
+    }
+
+    const storageKey = `${DATA_KEY_PREFIX}${currentUser}`;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(data));
+    } catch (error) {
+      console.warn('Impossible de sauvegarder les données locales :', error);
+    }
+  }
+
+  function cloneDefaultData() {
+    return {
+      metrics: { ...defaultData.metrics },
+      keywords: [],
+      lastUpdated: null,
+    };
+  }
+
+  function loadUserStore() {
+    try {
+      const stored = window.localStorage.getItem(USER_STORE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed && typeof parsed === 'object' && parsed.users) {
+          const users =
+            parsed.users && typeof parsed.users === 'object' ? parsed.users : {};
+          return {
+            users: { ...users },
+          };
+        }
+      }
+    } catch (error) {
+      console.warn('Impossible de charger les comptes utilisateurs :', error);
+    }
+    return { users: {} };
+  }
+
+  function saveUserStore(store) {
+    try {
+      window.localStorage.setItem(USER_STORE_KEY, JSON.stringify(store));
+    } catch (error) {
+      console.warn('Impossible de sauvegarder les comptes utilisateurs :', error);
+    }
+  }
+
+  function saveActiveUser(username) {
+    try {
+      window.localStorage.setItem(ACTIVE_USER_KEY, username);
+    } catch (error) {
+      console.warn("Impossible d'enregistrer l'utilisateur actif :", error);
+    }
+  }
+
+  function loadActiveUser() {
+    try {
+      return window.localStorage.getItem(ACTIVE_USER_KEY);
+    } catch (error) {
+      console.warn("Impossible de charger l'utilisateur actif :", error);
+      return null;
+    }
+  }
+
+  function clearActiveUser() {
+    try {
+      window.localStorage.removeItem(ACTIVE_USER_KEY);
+    } catch (error) {
+      console.warn("Impossible de réinitialiser l'utilisateur actif :", error);
+    }
+  }
+
+  function isValidEmail(value) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  }
+
+  async function hashPassword(password) {
+    const encoder = new TextEncoder();
+    const dataBuffer = encoder.encode(password);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 
   function generateId() {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -48,6 +48,87 @@ button {
   background: none;
 }
 
+.auth-view {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.auth-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  width: 100%;
+  max-width: 420px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.auth-title {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.auth-text {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-error {
+  min-height: 20px;
+  color: var(--color-danger);
+  font-weight: 600;
+  margin: 4px 0 0;
+}
+
+.auth-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.auth-switch {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.auth-link {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.auth-link:hover {
+  text-decoration: underline;
+}
+
+.auth-section[hidden] {
+  display: none;
+}
+
+.secondary-button {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
+  padding: 12px 18px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.secondary-button:hover {
+  background: rgba(15, 23, 42, 0.14);
+}
+
 .app {
   display: flex;
   min-height: 100vh;
@@ -111,6 +192,35 @@ button {
   font-size: 0.85rem;
   line-height: 1.4;
   color: rgba(226, 232, 240, 0.75);
+}
+
+.sidebar-user {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.sidebar-user-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.logout-button {
+  width: 100%;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-weight: 600;
+  margin-bottom: 20px;
+  transition: background 0.2s ease;
+}
+
+.logout-button:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .content {
@@ -474,6 +584,10 @@ button {
 }
 
 @media (max-width: 600px) {
+  .auth-card {
+    padding: 24px;
+  }
+
   .content {
     padding: 24px 18px 40px;
   }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,79 @@
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>
-    <div class="app">
+    <div id="auth-view" class="auth-view">
+      <div class="auth-card" role="dialog" aria-modal="true">
+        <section id="login-section" class="auth-section" aria-labelledby="login-title">
+          <h1 id="login-title" class="auth-title">Connexion</h1>
+          <p class="auth-text">
+            Identifiez-vous pour accéder à votre espace UManager sécurisé.
+          </p>
+          <form id="login-form" class="auth-form" autocomplete="off">
+            <div class="form-row">
+              <label for="login-username">Identifiant *</label>
+              <input id="login-username" name="username" type="text" required />
+            </div>
+            <div class="form-row">
+              <label for="login-password">Mot de passe *</label>
+              <input id="login-password" name="password" type="password" required />
+            </div>
+            <p id="login-error" class="auth-error" role="alert" aria-live="assertive"></p>
+            <button type="submit" class="primary-button">Se connecter</button>
+          </form>
+          <p class="auth-switch">
+            Pas encore de compte ?
+            <button id="show-register" type="button" class="auth-link">Créer un compte</button>
+          </p>
+        </section>
+        <section
+          id="register-section"
+          class="auth-section"
+          aria-labelledby="register-title"
+          hidden
+        >
+          <h1 id="register-title" class="auth-title">Créer un compte</h1>
+          <p class="auth-text">
+            Renseignez les informations suivantes pour activer votre espace personnel.
+          </p>
+          <form id="register-form" class="auth-form" autocomplete="off">
+            <div class="form-row">
+              <label for="register-username">Identifiant *</label>
+              <input id="register-username" name="username" type="text" required />
+            </div>
+            <div class="form-row">
+              <label for="register-email">Adresse mail *</label>
+              <input id="register-email" name="email" type="email" required />
+            </div>
+            <div class="form-row">
+              <label for="register-password">Mot de passe *</label>
+              <input
+                id="register-password"
+                name="password"
+                type="password"
+                minlength="6"
+                required
+              />
+            </div>
+            <div class="form-row">
+              <label for="register-password-confirm">Confirmer le mot de passe *</label>
+              <input
+                id="register-password-confirm"
+                name="password-confirm"
+                type="password"
+                minlength="6"
+                required
+              />
+            </div>
+            <p id="register-error" class="auth-error" role="alert" aria-live="assertive"></p>
+            <div class="auth-actions">
+              <button type="submit" class="primary-button">Créer le compte</button>
+              <button id="show-login" type="button" class="secondary-button">Retour</button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+    <div class="app" hidden>
       <aside class="sidebar" aria-label="Navigation principale">
         <div class="brand">
           <span class="brand-logo" aria-hidden="true">📊</span>
@@ -26,6 +98,11 @@
           </button>
         </nav>
         <div class="sidebar-footer">
+          <div class="sidebar-user" aria-live="polite">
+            <span class="sidebar-user-label">Connecté :</span>
+            <strong id="current-username">—</strong>
+          </div>
+          <button id="logout-button" class="logout-button" type="button">Se déconnecter</button>
           <p class="sidebar-tagline">
             Gérez vos données professionnelles, associations et structures en toute
             simplicité.


### PR DESCRIPTION
## Summary
- add a dedicated authentification interface with login and registration flows
- secure credentials by hashing passwords and bootstrapping admin accounts
- isolate local storage per user so metrics and keywords remain private and add logout handling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68caf1039bf08326a63e99867874103a