### PR TITLE
Add manual contact management features

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -381,7 +381,8 @@ button {
 }
 
 .keyword-form,
-.keyword-edit-form {
+.keyword-edit-form,
+.contact-form {
   background: var(--color-surface);
   padding: 24px;
   border-radius: var(--radius-lg);
@@ -410,6 +411,51 @@ button {
   resize: vertical;
 }
 
+.form-fieldset {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-fieldset legend {
+  font-weight: 600;
+  padding: 0 6px;
+}
+
+.form-hint {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.checkbox-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.checkbox-item label {
+  flex: 1;
+}
+
+.checkbox-item input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+}
+
 .primary-button {
   align-self: flex-start;
   background: var(--color-primary);
@@ -435,6 +481,113 @@ button {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.contact-search-panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 20px 24px;
+}
+
+.contact-search-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.contact-search-controls input,
+.contact-search-controls select {
+  flex: 1 1 220px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-size: 0.95rem;
+}
+
+.contact-search-controls select {
+  max-width: 280px;
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 24px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.contact-item {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.contact-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.contact-name {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.contact-created {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.contact-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--color-text-secondary);
+}
+
+.contact-details p {
+  margin: 0;
+}
+
+.contact-coordinates--empty,
+.contact-notes--empty {
+  font-style: italic;
+  color: rgba(71, 85, 105, 0.72);
+}
+
+.contact-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.keyword-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.keyword-chip--empty {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  font-style: italic;
 }
 
 .keyword-item {
@@ -581,6 +734,16 @@ button {
   .keyword-actions {
     align-self: flex-end;
   }
+
+  .contact-item {
+    gap: 12px;
+  }
+
+  .contact-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
 }
 
 @media (max-width: 600px) {
@@ -598,5 +761,14 @@ button {
 
   .metrics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .contact-search-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .contact-search-controls select {
+    max-width: 100%;
   }
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -24,6 +24,12 @@
           <button class="nav-button" data-target="keywords" type="button">
             Mots clés
           </button>
+          <button class="nav-button" data-target="contacts-add" type="button">
+            Ajouter des contacts
+          </button>
+          <button class="nav-button" data-target="contacts-search" type="button">
+            Recherche de contact
+          </button>
         </nav>
         <div class="sidebar-footer">
           <div class="sidebar-user" aria-live="polite">
@@ -181,8 +187,122 @@
             </p>
           </div>
         </section>
+        <section id="contacts-add" class="page" aria-labelledby="contacts-add-title">
+          <header class="page-header">
+            <div>
+              <h1 id="contacts-add-title">Ajouter un contact</h1>
+              <p class="page-subtitle">
+                Créez un contact manuellement et associez-le aux mots clés pertinents.
+              </p>
+            </div>
+            <div class="insight-card">
+              <span class="insight-label">Contacts enregistrés</span>
+              <span class="insight-value" id="contacts-count">0</span>
+            </div>
+          </header>
+          <form id="contact-form" class="contact-form" autocomplete="off">
+            <div class="form-row">
+              <label for="contact-name">Nom complet *</label>
+              <input
+                id="contact-name"
+                name="contact-name"
+                type="text"
+                required
+                maxlength="120"
+                placeholder="Ex. Jeanne Dupont"
+              />
+            </div>
+            <div class="form-row">
+              <label for="contact-email">Adresse e-mail</label>
+              <input
+                id="contact-email"
+                name="contact-email"
+                type="email"
+                maxlength="160"
+                placeholder="Ex. jeanne.dupont@email.fr"
+              />
+            </div>
+            <div class="form-row">
+              <label for="contact-phone">Téléphone</label>
+              <input
+                id="contact-phone"
+                name="contact-phone"
+                type="tel"
+                maxlength="40"
+                placeholder="Ex. 06 12 34 56 78"
+              />
+            </div>
+            <fieldset id="contact-keywords-fieldset" class="form-fieldset">
+              <legend>Mots clés associés</legend>
+              <p class="form-hint">
+                Sélectionnez un ou plusieurs mots clés pour catégoriser ce contact.
+              </p>
+              <div id="contact-keywords-container" class="checkbox-grid" aria-live="polite"></div>
+              <p id="contact-keywords-empty" class="empty-state" hidden>
+                Aucun mot clé disponible pour le moment. Ajoutez vos catégories dans l’onglet «&nbsp;Mots clés&nbsp;».
+              </p>
+            </fieldset>
+            <div class="form-row">
+              <label for="contact-notes">Notes</label>
+              <textarea
+                id="contact-notes"
+                name="contact-notes"
+                rows="3"
+                maxlength="500"
+                placeholder="Informations complémentaires (optionnel)."
+              ></textarea>
+            </div>
+            <button type="submit" class="primary-button">Ajouter le contact</button>
+          </form>
+        </section>
+        <section id="contacts-search" class="page" aria-labelledby="contacts-search-title">
+          <header class="page-header">
+            <div>
+              <h1 id="contacts-search-title">Recherche de contact</h1>
+              <p class="page-subtitle">
+                Parcourez les contacts enregistrés et filtrez-les grâce aux mots clés.
+              </p>
+            </div>
+            <div class="insight-card">
+              <span class="insight-label">Résultats affichés</span>
+              <span class="insight-value" id="contact-search-count">0</span>
+            </div>
+          </header>
+          <div class="contact-search-panel">
+            <div class="contact-search-controls">
+              <label class="sr-only" for="contact-search-input">Rechercher un contact</label>
+              <input
+                id="contact-search-input"
+                type="search"
+                placeholder="Rechercher par nom, e-mail, téléphone ou mot clé"
+                autocomplete="off"
+              />
+              <label class="sr-only" for="contact-keyword-filter">Filtrer par mot clé</label>
+              <select id="contact-keyword-filter">
+                <option value="__all__">Tous les mots clés</option>
+              </select>
+            </div>
+          </div>
+          <ul id="contact-list" class="contact-list" aria-live="polite"></ul>
+          <p id="contact-empty-state" class="empty-state" hidden>
+            Ajoutez vos premiers contacts pour les retrouver ici.
+          </p>
+        </section>
       </main>
     </div>
+    <template id="contact-item-template">
+      <li class="contact-item">
+        <div class="contact-header">
+          <h3 class="contact-name"></h3>
+          <span class="contact-created"></span>
+        </div>
+        <div class="contact-details">
+          <p class="contact-coordinates"></p>
+          <p class="contact-notes"></p>
+        </div>
+        <div class="contact-keywords"></div>
+      </li>
+    </template>
     <template id="keyword-item-template">
       <li class="keyword-item">
         <div class="keyword-main">


### PR DESCRIPTION
## Summary
- add dashboard navigation entries and sections to manually create contacts and search existing ones
- persist contacts beside keywords, render them with keyword filters, and expose counts on the dashboard
- style the new contact form, search panel, and contact list so they match the existing UI

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb09720be883269eae115014a53c22