### PR TITLE
Fix category type constants initialization order

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -323,13 +323,16 @@
     const categoryList = document.getElementById('category-list');
     const categoryEmptyState = document.getElementById('category-empty-state');
     const categoryTemplate = document.getElementById('category-item-template');
+    const categoryTypeSelect = document.getElementById('category-type');
+    const categoryOptionsRow = document.getElementById('category-options-row');
+    const categoryOptionsInput = document.getElementById('category-options');
     const keywordForm = document.getElementById('keyword-form');
     const keywordList = document.getElementById('keyword-list');
     const keywordEmptyState = document.getElementById('keyword-empty-state');
     const keywordTemplate = document.getElementById('keyword-item-template');
     const contactsCountEl = document.getElementById('contacts-count');
     const contactForm = document.getElementById('contact-form');
-    const contactCategoriesContainer = document.getElementById('contact-categories-container');
+    const contactCategoryFieldsContainer = document.getElementById('contact-category-fields');
     const contactCategoriesEmpty = document.getElementById('contact-categories-empty');
     const contactKeywordsContainer = document.getElementById('contact-keywords-container');
     const contactKeywordsEmpty = document.getElementById('contact-keywords-empty');
@@ -341,6 +344,17 @@
     const searchKeywordsSelect = document.getElementById('search-keywords');
     const contactSearchCountEl = document.getElementById('contact-search-count');
     const contactTemplate = document.getElementById('contact-item-template');
+    const contactSubmitButton = document.getElementById('contact-submit-button');
+    const contactCancelEditButton = document.getElementById('contact-cancel-edit');
+
+    const CATEGORY_TYPE_ORDER = ['text', 'number', 'date', 'list'];
+    const CATEGORY_TYPES = new Set(CATEGORY_TYPE_ORDER);
+    const CATEGORY_TYPE_LABELS = {
+      text: 'Texte',
+      number: 'Nombre',
+      date: 'Date',
+      list: 'Liste',
+    };
 
     let data = loadDataForUser(currentUser);
     data = upgradeDataStructure(data);
@@ -356,6 +370,13 @@
       logoutButton.addEventListener('click', () => {
         clearActiveUser();
         navigateToLogin();
+      });
+    }
+
+    updateCategoryOptionsVisibility();
+    if (categoryTypeSelect) {
+      categoryTypeSelect.addEventListener('change', () => {
+        updateCategoryOptionsVisibility();
       });
     }
 
@@ -401,6 +422,28 @@
         const formData = new FormData(categoryForm);
         const name = (formData.get('category-name') || '').toString().trim();
         const description = (formData.get('category-description') || '').toString().trim();
+        let typeValue = (formData.get('category-type') || 'text').toString();
+        if (!CATEGORY_TYPES.has(typeValue)) {
+          typeValue = 'text';
+        }
+
+        let options = [];
+        if (categoryOptionsInput instanceof HTMLTextAreaElement) {
+          categoryOptionsInput.setCustomValidity('');
+        }
+
+        if (typeValue === 'list') {
+          const rawOptions = (formData.get('category-options') || '').toString();
+          options = parseCategoryOptions(rawOptions);
+          if (categoryOptionsInput instanceof HTMLTextAreaElement) {
+            if (options.length === 0) {
+              categoryOptionsInput.setCustomValidity('Veuillez renseigner au moins une valeur.');
+              categoryOptionsInput.reportValidity();
+              return;
+            }
+            categoryOptionsInput.setCustomValidity('');
+          }
+        }
 
         if (!name) {
           const nameInput = categoryForm.querySelector('#category-name');
@@ -414,17 +457,29 @@
           id: generateId('category'),
           name,
           description,
+          type: typeValue,
+          options,
         });
 
         data.lastUpdated = new Date().toISOString();
         saveDataForUser(currentUser, data);
         categoryForm.reset();
+        updateCategoryOptionsVisibility();
         const nameInput = categoryForm.querySelector('#category-name');
         if (nameInput instanceof HTMLInputElement) {
           nameInput.focus();
         }
         renderMetrics();
         renderCategories();
+      });
+
+      categoryForm.addEventListener('reset', () => {
+        window.requestAnimationFrame(() => {
+          if (categoryOptionsInput instanceof HTMLTextAreaElement) {
+            categoryOptionsInput.setCustomValidity('');
+          }
+          updateCategoryOptionsVisibility();
+        });
       });
     }
 
@@ -487,10 +542,59 @@
         const customField = (formData.get('contact-custom-field') || '').toString().trim();
         const organization = (formData.get('contact-organization') || '').toString().trim();
         const notes = (formData.get('contact-notes') || '').toString().trim();
-        const categoryIds = formData
-          .getAll('contact-categories')
-          .map((value) => value.toString());
         const keywordIds = formData.getAll('contact-keywords').map((value) => value.toString());
+
+        const categoryInputs = contactForm.querySelectorAll('[data-category-input]');
+        const categoryValues = {};
+        let hasInvalidCategoryValue = false;
+
+        categoryInputs.forEach((element) => {
+          if (
+            !(
+              element instanceof HTMLInputElement ||
+              element instanceof HTMLTextAreaElement ||
+              element instanceof HTMLSelectElement
+            )
+          ) {
+            return;
+          }
+
+          element.setCustomValidity('');
+          if (!element.checkValidity()) {
+            element.reportValidity();
+            hasInvalidCategoryValue = true;
+            return;
+          }
+
+          const categoryId = element.dataset.categoryId || '';
+          if (!categoryId) {
+            return;
+          }
+
+          const type = element.dataset.categoryType || 'text';
+          const rawValue = element.value != null ? element.value.toString().trim() : '';
+          if (!rawValue) {
+            return;
+          }
+
+          if (type === 'number') {
+            const parsed = Number(element.value);
+            if (Number.isFinite(parsed)) {
+              categoryValues[categoryId] = parsed.toString();
+            } else {
+              element.setCustomValidity('Veuillez renseigner un nombre valide.');
+              element.reportValidity();
+              hasInvalidCategoryValue = true;
+            }
+            return;
+          }
+
+          categoryValues[categoryId] = element.value.toString().trim();
+        });
+
+        if (hasInvalidCategoryValue) {
+          return;
+        }
 
         const firstNameInput = contactForm.querySelector('#contact-first-name');
         if (!firstName) {
@@ -519,46 +623,86 @@
         }
 
         const fullName = `${firstName} ${usageName}`.trim();
+        const editingId = contactForm.dataset.editingId || '';
+        const editingIndex = editingId
+          ? data.contacts.findIndex((contact) => contact.id === editingId)
+          : -1;
 
-        data.contacts.push({
-          id: generateId('contact'),
-          firstName,
-          usageName,
-          birthName,
-          fullName: fullName || usageName || firstName,
-          gender,
-          ageRange,
-          email,
-          mobile,
-          landline,
-          phone: mobile || landline,
-          street,
-          city,
-          postalCode,
-          country,
-          zone,
-          campaignStatus,
-          engagementLevel,
-          archiveTheme,
-          mandate,
-          profession,
-          lastMembership,
-          customField,
-          organization,
-          notes,
-          categories: categoryIds,
-          keywords: keywordIds,
-          createdAt: new Date().toISOString(),
-        });
+        if (editingId && editingIndex !== -1) {
+          const contactToUpdate = data.contacts[editingIndex];
+          contactToUpdate.firstName = firstName;
+          contactToUpdate.usageName = usageName;
+          contactToUpdate.birthName = birthName;
+          contactToUpdate.fullName = fullName || usageName || firstName;
+          contactToUpdate.gender = gender;
+          contactToUpdate.ageRange = ageRange;
+          contactToUpdate.email = email;
+          contactToUpdate.mobile = mobile;
+          contactToUpdate.landline = landline;
+          contactToUpdate.phone = mobile || landline;
+          contactToUpdate.street = street;
+          contactToUpdate.city = city;
+          contactToUpdate.postalCode = postalCode;
+          contactToUpdate.country = country;
+          contactToUpdate.zone = zone;
+          contactToUpdate.campaignStatus = campaignStatus;
+          contactToUpdate.engagementLevel = engagementLevel;
+          contactToUpdate.archiveTheme = archiveTheme;
+          contactToUpdate.mandate = mandate;
+          contactToUpdate.profession = profession;
+          contactToUpdate.lastMembership = lastMembership;
+          contactToUpdate.customField = customField;
+          contactToUpdate.organization = organization;
+          contactToUpdate.notes = notes;
+          contactToUpdate.categoryValues = { ...categoryValues };
+          contactToUpdate.keywords = keywordIds;
+          contactToUpdate.updatedAt = new Date().toISOString();
+        } else {
+          data.contacts.push({
+            id: generateId('contact'),
+            firstName,
+            usageName,
+            birthName,
+            fullName: fullName || usageName || firstName,
+            gender,
+            ageRange,
+            email,
+            mobile,
+            landline,
+            phone: mobile || landline,
+            street,
+            city,
+            postalCode,
+            country,
+            zone,
+            campaignStatus,
+            engagementLevel,
+            archiveTheme,
+            mandate,
+            profession,
+            lastMembership,
+            customField,
+            organization,
+            notes,
+            categoryValues: { ...categoryValues },
+            keywords: keywordIds,
+            createdAt: new Date().toISOString(),
+            updatedAt: null,
+          });
+        }
 
         data.lastUpdated = new Date().toISOString();
+        updateMetricsFromContacts();
         saveDataForUser(currentUser, data);
-        contactForm.reset();
-        if (firstNameInput instanceof HTMLInputElement) {
-          firstNameInput.focus();
-        }
+        resetContactForm();
         renderMetrics();
         renderContacts();
+      });
+    }
+
+    if (contactCancelEditButton) {
+      contactCancelEditButton.addEventListener('click', () => {
+        resetContactForm();
       });
     }
 
@@ -678,7 +822,7 @@
 
     function renderCategories() {
       if (!categoryList || !categoryEmptyState) {
-        renderContactCategoryOptions();
+        renderContactCategoryFields();
         renderSearchCategoryOptions();
         renderContacts();
         return;
@@ -692,7 +836,7 @@
 
       if (categories.length === 0) {
         categoryEmptyState.hidden = false;
-        renderContactCategoryOptions();
+        renderContactCategoryFields();
         renderSearchCategoryOptions();
         renderContacts();
         return;
@@ -715,6 +859,7 @@
 
         const titleEl = listItem.querySelector('.category-title');
         const descriptionEl = listItem.querySelector('.category-description');
+        const metaEl = listItem.querySelector('.category-meta');
         const editButton = listItem.querySelector('[data-action="edit"]');
         const deleteButton = listItem.querySelector('[data-action="delete"]');
 
@@ -725,6 +870,17 @@
         if (descriptionEl) {
           descriptionEl.textContent = category.description || 'Aucune description renseignée.';
           descriptionEl.classList.toggle('category-description--empty', !category.description);
+        }
+
+        if (metaEl) {
+          const typeKey = CATEGORY_TYPES.has(category.type) ? category.type : 'text';
+          const typeLabel = CATEGORY_TYPE_LABELS[typeKey] || CATEGORY_TYPE_LABELS.text;
+          let metaText = `Type : ${typeLabel}`;
+          if (typeKey === 'list') {
+            const options = Array.isArray(category.options) ? category.options.filter((value) => value) : [];
+            metaText += options.length > 0 ? ` · ${options.join(', ')}` : ' · Aucune valeur définie';
+          }
+          metaEl.textContent = metaText;
         }
 
         if (editButton) {
@@ -743,7 +899,7 @@
       });
 
       categoryList.appendChild(fragment);
-      renderContactCategoryOptions();
+      renderContactCategoryFields();
       renderSearchCategoryOptions();
       renderContacts();
     }
@@ -820,49 +976,152 @@
       renderContacts();
     }
 
-    function renderContactCategoryOptions() {
+    function renderContactCategoryFields() {
       const categories = Array.isArray(data.categories)
         ? data.categories.slice().sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }))
         : [];
 
-      if (contactCategoriesContainer) {
-        contactCategoriesContainer.innerHTML = '';
-
-        if (categories.length === 0) {
-          if (contactCategoriesEmpty) {
-            contactCategoriesEmpty.hidden = false;
-          }
-        } else {
-          if (contactCategoriesEmpty) {
-            contactCategoriesEmpty.hidden = true;
-          }
-
-          const fragment = document.createDocumentFragment();
-
-          categories.forEach((category) => {
-            const checkboxId = `contact-category-${category.id}`;
-            const item = document.createElement('div');
-            item.className = 'checkbox-item';
-
-            const input = document.createElement('input');
-            input.type = 'checkbox';
-            input.id = checkboxId;
-            input.name = 'contact-categories';
-            input.value = category.id || '';
-
-            const label = document.createElement('label');
-            label.setAttribute('for', checkboxId);
-            label.textContent = category.name;
-
-            item.append(input, label);
-            fragment.appendChild(item);
-          });
-
-          contactCategoriesContainer.appendChild(fragment);
+      if (!contactCategoryFieldsContainer) {
+        if (contactCategoriesEmpty) {
+          contactCategoriesEmpty.hidden = categories.length > 0;
         }
-      } else if (contactCategoriesEmpty) {
-        contactCategoriesEmpty.hidden = categories.length > 0;
+        return;
       }
+
+      const previousValues = new Map();
+      contactCategoryFieldsContainer.querySelectorAll('[data-category-input]').forEach((element) => {
+        if (
+          !element ||
+          !(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement)
+        ) {
+          return;
+        }
+        const categoryId = element.dataset.categoryId || '';
+        if (categoryId) {
+          previousValues.set(categoryId, element.value);
+        }
+      });
+
+      contactCategoryFieldsContainer.innerHTML = '';
+
+      if (categories.length === 0) {
+        if (contactCategoriesEmpty) {
+          contactCategoriesEmpty.hidden = false;
+        }
+        return;
+      }
+
+      if (contactCategoriesEmpty) {
+        contactCategoriesEmpty.hidden = true;
+      }
+
+      const editingId = contactForm && contactForm.dataset.editingId ? contactForm.dataset.editingId : '';
+      let editingValues = null;
+      if (editingId) {
+        const editingContact = data.contacts.find((contact) => contact.id === editingId);
+        if (editingContact && editingContact.categoryValues && typeof editingContact.categoryValues === 'object') {
+          editingValues = editingContact.categoryValues;
+        }
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      categories.forEach((category) => {
+        const fieldWrapper = document.createElement('div');
+        fieldWrapper.className = 'form-row';
+
+        const fieldId = `contact-category-${category.id}`;
+        const label = document.createElement('label');
+        label.setAttribute('for', fieldId);
+        label.textContent = category.name;
+
+        const description = (category.description || '').toString().trim();
+        let input;
+
+        const baseType = CATEGORY_TYPES.has(category.type) ? category.type : 'text';
+
+        if (baseType === 'number') {
+          const numberInput = document.createElement('input');
+          numberInput.type = 'number';
+          numberInput.inputMode = 'decimal';
+          numberInput.id = fieldId;
+          numberInput.name = `contact-category-${category.id}`;
+          if (description) {
+            numberInput.placeholder = description;
+          }
+          input = numberInput;
+        } else if (baseType === 'date') {
+          const dateInput = document.createElement('input');
+          dateInput.type = 'date';
+          dateInput.id = fieldId;
+          dateInput.name = `contact-category-${category.id}`;
+          input = dateInput;
+        } else if (baseType === 'list') {
+          const select = document.createElement('select');
+          select.id = fieldId;
+          select.name = `contact-category-${category.id}`;
+
+          const defaultOption = document.createElement('option');
+          defaultOption.value = '';
+          defaultOption.textContent = 'Sélectionnez une valeur';
+          select.appendChild(defaultOption);
+
+          const options = Array.isArray(category.options) ? category.options : [];
+          options.forEach((optionValue) => {
+            const option = document.createElement('option');
+            option.value = optionValue;
+            option.textContent = optionValue;
+            select.appendChild(option);
+          });
+          input = select;
+        } else {
+          const textInput = document.createElement('input');
+          textInput.type = 'text';
+          textInput.id = fieldId;
+          textInput.name = `contact-category-${category.id}`;
+          textInput.maxLength = 200;
+          if (description) {
+            textInput.placeholder = description;
+          }
+          input = textInput;
+        }
+
+        input.dataset.categoryId = category.id || '';
+        input.dataset.categoryType = baseType;
+        input.setAttribute('data-category-input', 'true');
+
+        let initialValue = '';
+        if (category.id && previousValues.has(category.id)) {
+          initialValue = previousValues.get(category.id) || '';
+        } else if (category.id && editingValues && category.id in editingValues) {
+          const rawValue = editingValues[category.id];
+          initialValue = rawValue != null ? rawValue.toString() : '';
+        }
+
+        if (input instanceof HTMLSelectElement) {
+          const options = Array.from(input.options).map((option) => option.value);
+          if (options.includes(initialValue)) {
+            input.value = initialValue;
+          } else {
+            input.value = '';
+          }
+        } else if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+          input.value = initialValue;
+        }
+
+        fieldWrapper.append(label, input);
+
+        if (description && (baseType === 'list' || baseType === 'date')) {
+          const hint = document.createElement('p');
+          hint.className = 'form-hint';
+          hint.textContent = description;
+          fieldWrapper.appendChild(hint);
+        }
+
+        fragment.appendChild(fieldWrapper);
+      });
+
+      contactCategoryFieldsContainer.appendChild(fragment);
     }
 
     function renderContactKeywordOptions() {
@@ -871,6 +1130,23 @@
         : [];
 
       if (contactKeywordsContainer) {
+        const previousSelection = new Set();
+        contactKeywordsContainer
+          .querySelectorAll('input[name="contact-keywords"]')
+          .forEach((input) => {
+            if (input instanceof HTMLInputElement && input.checked) {
+              previousSelection.add(input.value);
+            }
+          });
+
+        const editingContactId = contactForm && contactForm.dataset.editingId ? contactForm.dataset.editingId : '';
+        const editingContact = editingContactId
+          ? data.contacts.find((contact) => contact.id === editingContactId)
+          : null;
+        const editingKeywords = editingContact && Array.isArray(editingContact.keywords)
+          ? new Set(editingContact.keywords)
+          : new Set();
+
         contactKeywordsContainer.innerHTML = '';
 
         if (keywords.length === 0) {
@@ -894,6 +1170,9 @@
             input.id = checkboxId;
             input.name = 'contact-keywords';
             input.value = keyword.id || '';
+            if (keyword.id && (previousSelection.has(keyword.id) || editingKeywords.has(keyword.id))) {
+              input.checked = true;
+            }
 
             const label = document.createElement('label');
             label.setAttribute('for', checkboxId);
@@ -1055,11 +1334,21 @@
 
       const filteredContacts = contacts
         .filter((contact) => {
-          const categories = Array.isArray(contact.categories) ? contact.categories : [];
+          const categoryValues =
+            contact && typeof contact === 'object' && contact.categoryValues && typeof contact.categoryValues === 'object'
+              ? contact.categoryValues
+              : {};
           const keywords = Array.isArray(contact.keywords) ? contact.keywords : [];
 
-          if (exactFilters.category && !categories.includes(exactFilters.category)) {
-            return false;
+          if (exactFilters.category) {
+            const rawCategoryValue = categoryValues[exactFilters.category];
+            const normalizedCategoryValue =
+              rawCategoryValue === undefined || rawCategoryValue === null
+                ? ''
+                : rawCategoryValue.toString().trim();
+            if (!normalizedCategoryValue) {
+              return false;
+            }
           }
 
           if (keywordFilters.length > 0) {
@@ -1174,18 +1463,38 @@
             return true;
           }
 
-          const categoryNames = categories
-            .map((categoryId) => {
+          const categoryEntries = Object.entries(categoryValues)
+            .map(([categoryId, rawValue]) => {
               const category = categoriesById.get(categoryId);
-              return category ? category.name : '';
+              if (!category) {
+                return null;
+              }
+              const valueString = rawValue === undefined || rawValue === null ? '' : rawValue.toString();
+              return {
+                id: categoryId,
+                name: category.name,
+                value: valueString,
+              };
             })
-            .filter(Boolean);
+            .filter((entry) => Boolean(entry));
           const keywordNames = keywords
             .map((keywordId) => {
               const keyword = keywordsById.get(keywordId);
               return keyword ? keyword.name : '';
             })
             .filter(Boolean);
+
+          const categoryNames = categoryEntries
+            .map((entry) => entry && entry.name)
+            .filter((value) => Boolean(value));
+          const categoryValueTexts = categoryEntries
+            .map((entry) => {
+              if (!entry) {
+                return '';
+              }
+              return entry.value != null ? entry.value.toString().trim() : '';
+            })
+            .filter((value) => Boolean(value));
 
           const haystackParts = [
             contact.fullName || '',
@@ -1200,6 +1509,7 @@
             contact.city || '',
             contact.customField || '',
             categoryNames.join(' '),
+            categoryValueTexts.join(' '),
             keywordNames.join(' '),
           ];
 
@@ -1306,25 +1616,38 @@
         const categoriesContainer = listItem.querySelector('.contact-categories');
         if (categoriesContainer) {
           categoriesContainer.innerHTML = '';
-          const associatedCategories = Array.isArray(contact.categories)
-            ? contact.categories
-                .map((categoryId) => categoriesById.get(categoryId))
-                .filter((category) => Boolean(category))
-            : [];
+          const categoryValues =
+            contact && typeof contact === 'object' && contact.categoryValues && typeof contact.categoryValues === 'object'
+              ? contact.categoryValues
+              : {};
+
+          const associatedCategories = Object.entries(categoryValues)
+            .map(([categoryId, rawValue]) => {
+              const category = categoriesById.get(categoryId);
+              if (!category) {
+                return null;
+              }
+              const valueString = rawValue === undefined || rawValue === null ? '' : rawValue.toString().trim();
+              return { name: category.name, value: valueString };
+            })
+            .filter((entry) => entry && entry.value);
 
           if (associatedCategories.length > 0) {
             associatedCategories
               .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }))
-              .forEach((category) => {
+              .forEach((entry) => {
+                if (!entry) {
+                  return;
+                }
                 const chip = document.createElement('span');
                 chip.className = 'category-chip';
-                chip.textContent = category.name;
+                chip.textContent = `${entry.name} : ${entry.value}`;
                 categoriesContainer.appendChild(chip);
               });
           } else {
             const chip = document.createElement('span');
             chip.className = 'category-chip category-chip--empty';
-            chip.textContent = 'Sans catégorie';
+            chip.textContent = 'Aucune donnée personnalisée';
             categoriesContainer.appendChild(chip);
           }
         }
@@ -1355,10 +1678,135 @@
           }
         }
 
+        const editContactButton = listItem.querySelector('[data-action="edit-contact"]');
+        if (editContactButton instanceof HTMLButtonElement) {
+          if (contact.id) {
+            editContactButton.disabled = false;
+            editContactButton.addEventListener('click', () => {
+              startContactEdition(contact.id);
+            });
+          } else {
+            editContactButton.disabled = true;
+          }
+        }
+
         fragment.appendChild(listItem);
       });
 
       contactList.appendChild(fragment);
+    }
+
+    function resetContactForm() {
+      if (!contactForm) {
+        return;
+      }
+
+      contactForm.reset();
+      exitContactEditMode();
+      renderContactCategoryFields();
+
+      if (contactKeywordsContainer) {
+        contactKeywordsContainer
+          .querySelectorAll('input[name="contact-keywords"]')
+          .forEach((input) => {
+            if (input instanceof HTMLInputElement) {
+              input.checked = false;
+            }
+          });
+      }
+
+      const firstNameInput = contactForm.querySelector('#contact-first-name');
+      if (firstNameInput instanceof HTMLInputElement) {
+        firstNameInput.focus();
+      }
+    }
+
+    function exitContactEditMode() {
+      if (!contactForm) {
+        return;
+      }
+
+      delete contactForm.dataset.editingId;
+      if (contactSubmitButton) {
+        contactSubmitButton.textContent = 'Ajouter le contact';
+      }
+      if (contactCancelEditButton) {
+        contactCancelEditButton.hidden = true;
+      }
+    }
+
+    function startContactEdition(contactId) {
+      if (!contactForm) {
+        return;
+      }
+
+      const contact = data.contacts.find((item) => item.id === contactId);
+      if (!contact) {
+        return;
+      }
+
+      showPage('contacts-add');
+      contactForm.reset();
+      contactForm.dataset.editingId = contactId;
+      if (contactSubmitButton) {
+        contactSubmitButton.textContent = 'Enregistrer les modifications';
+      }
+      if (contactCancelEditButton) {
+        contactCancelEditButton.hidden = false;
+      }
+
+      const assignValue = (selector, value) => {
+        const element = contactForm.querySelector(selector);
+        if (
+          element instanceof HTMLInputElement ||
+          element instanceof HTMLSelectElement ||
+          element instanceof HTMLTextAreaElement
+        ) {
+          element.value = value != null ? value : '';
+        }
+      };
+
+      assignValue('#contact-first-name', contact.firstName || '');
+      assignValue('#contact-usage-name', contact.usageName || '');
+      assignValue('#contact-birth-name', contact.birthName || '');
+      assignValue('#contact-gender', contact.gender || '');
+      assignValue('#contact-age-range', contact.ageRange || '');
+      assignValue('#contact-email', contact.email || '');
+      assignValue('#contact-mobile', contact.mobile || '');
+      assignValue('#contact-landline', contact.landline || '');
+      assignValue('#contact-street', contact.street || '');
+      assignValue('#contact-city', contact.city || '');
+      assignValue('#contact-postal-code', contact.postalCode || '');
+      assignValue('#contact-country', contact.country || '');
+      assignValue('#contact-zone', contact.zone || '');
+      assignValue('#contact-campaign-status', contact.campaignStatus || '');
+      assignValue('#contact-engagement-level', contact.engagementLevel || '');
+      assignValue('#contact-archive-theme', contact.archiveTheme || '');
+      assignValue('#contact-mandate', contact.mandate || '');
+      assignValue('#contact-profession', contact.profession || '');
+      assignValue('#contact-last-membership', contact.lastMembership || '');
+      assignValue('#contact-custom-field', contact.customField || '');
+      assignValue('#contact-organization', contact.organization || '');
+      assignValue('#contact-notes', contact.notes || '');
+
+      renderContactCategoryFields();
+
+      const keywordIds = Array.isArray(contact.keywords) ? new Set(contact.keywords) : new Set();
+      if (contactKeywordsContainer) {
+        contactKeywordsContainer
+          .querySelectorAll('input[name="contact-keywords"]')
+          .forEach((input) => {
+            if (input instanceof HTMLInputElement) {
+              input.checked = keywordIds.has(input.value);
+            }
+          });
+      }
+
+      const firstNameInput = contactForm.querySelector('#contact-first-name');
+      if (firstNameInput instanceof HTMLInputElement) {
+        firstNameInput.focus();
+        firstNameInput.setSelectionRange(firstNameInput.value.length, firstNameInput.value.length);
+      }
     }
 
     function startCategoryEdition(categoryId) {
@@ -1407,6 +1855,62 @@
       descriptionInput.value = category.description || '';
       descriptionRow.append(descriptionLabel, descriptionInput);
 
+      const typeRow = document.createElement('div');
+      typeRow.className = 'form-row';
+      const typeLabel = document.createElement('label');
+      const typeSelect = document.createElement('select');
+      const typeId = `edit-category-type-${categoryId}`;
+      typeLabel.setAttribute('for', typeId);
+      typeLabel.textContent = 'Type de valeur *';
+      typeSelect.id = typeId;
+      typeSelect.name = 'type';
+      CATEGORY_TYPE_ORDER.forEach((typeKey) => {
+        const option = document.createElement('option');
+        option.value = typeKey;
+        option.textContent = CATEGORY_TYPE_LABELS[typeKey] || typeKey;
+        if (typeKey === (CATEGORY_TYPES.has(category.type) ? category.type : 'text')) {
+          option.selected = true;
+        }
+        typeSelect.appendChild(option);
+      });
+      typeRow.append(typeLabel, typeSelect);
+
+      const optionsRow = document.createElement('div');
+      optionsRow.className = 'form-row';
+      const optionsLabel = document.createElement('label');
+      const optionsTextarea = document.createElement('textarea');
+      const optionsId = `edit-category-options-${categoryId}`;
+      optionsLabel.setAttribute('for', optionsId);
+      optionsLabel.textContent = 'Liste de valeurs';
+      optionsTextarea.id = optionsId;
+      optionsTextarea.name = 'options';
+      optionsTextarea.rows = 3;
+      optionsTextarea.maxLength = 500;
+      optionsTextarea.value = Array.isArray(category.options) ? category.options.join('\n') : '';
+      const optionsHint = document.createElement('p');
+      optionsHint.className = 'form-hint';
+      optionsHint.textContent = 'Saisissez une valeur par ligne.';
+      optionsRow.append(optionsLabel, optionsTextarea, optionsHint);
+
+      const toggleOptionsRow = () => {
+        const shouldShow = typeSelect.value === 'list';
+        if (shouldShow) {
+          optionsRow.hidden = false;
+          optionsRow.removeAttribute('hidden');
+        } else {
+          optionsRow.hidden = true;
+          if (!optionsRow.hasAttribute('hidden')) {
+            optionsRow.setAttribute('hidden', '');
+          }
+          optionsTextarea.setCustomValidity('');
+        }
+      };
+
+      toggleOptionsRow();
+      typeSelect.addEventListener('change', () => {
+        toggleOptionsRow();
+      });
+
       const actionsRow = document.createElement('div');
       actionsRow.className = 'category-edit-actions';
       const cancelButton = document.createElement('button');
@@ -1419,12 +1923,26 @@
       saveButton.textContent = 'Enregistrer';
       actionsRow.append(cancelButton, saveButton);
 
-      form.append(nameRow, descriptionRow, actionsRow);
+      form.append(nameRow, descriptionRow, typeRow, optionsRow, actionsRow);
 
       form.addEventListener('submit', (event) => {
         event.preventDefault();
         const name = nameInput.value.trim();
         const description = descriptionInput.value.trim();
+        let typeValue = typeSelect.value;
+        if (!CATEGORY_TYPES.has(typeValue)) {
+          typeValue = 'text';
+        }
+        let optionValues = [];
+        optionsTextarea.setCustomValidity('');
+        if (typeValue === 'list') {
+          optionValues = parseCategoryOptions(optionsTextarea.value || '');
+          if (optionValues.length === 0) {
+            optionsTextarea.setCustomValidity('Veuillez renseigner au moins une valeur.');
+            optionsTextarea.reportValidity();
+            return;
+          }
+        }
 
         if (!name) {
           nameInput.focus();
@@ -1433,6 +1951,9 @@
 
         category.name = name;
         category.description = description;
+        category.type = typeValue;
+        category.options = optionValues;
+        cleanupContactCategoryValues();
         data.lastUpdated = new Date().toISOString();
         saveDataForUser(currentUser, data);
         renderMetrics();
@@ -1452,17 +1973,152 @@
       data.categories = data.categories.filter((item) => item.id !== categoryId);
       if (Array.isArray(data.contacts)) {
         data.contacts.forEach((contact) => {
-          if (Array.isArray(contact.categories)) {
-            contact.categories = contact.categories.filter((item) => item !== categoryId);
-          } else {
-            contact.categories = [];
+          if (contact && contact.categoryValues && typeof contact.categoryValues === 'object') {
+            delete contact.categoryValues[categoryId];
           }
         });
       }
+      cleanupContactCategoryValues();
       data.lastUpdated = new Date().toISOString();
       saveDataForUser(currentUser, data);
       renderMetrics();
       renderCategories();
+    }
+
+    function updateCategoryOptionsVisibility() {
+      if (!categoryOptionsRow) {
+        return;
+      }
+
+      const currentType = categoryTypeSelect ? categoryTypeSelect.value : 'text';
+      if (currentType === 'list') {
+        categoryOptionsRow.hidden = false;
+        categoryOptionsRow.removeAttribute('hidden');
+        return;
+      }
+
+      categoryOptionsRow.hidden = true;
+      if (!categoryOptionsRow.hasAttribute('hidden')) {
+        categoryOptionsRow.setAttribute('hidden', '');
+      }
+      if (categoryOptionsInput instanceof HTMLTextAreaElement) {
+        categoryOptionsInput.setCustomValidity('');
+        categoryOptionsInput.value = '';
+      }
+    }
+
+    function parseCategoryOptions(rawValue) {
+      if (!rawValue) {
+        return [];
+      }
+
+      const values = rawValue
+        .split(/\r?\n|,/)
+        .map((value) => value.trim())
+        .filter((value) => Boolean(value));
+
+      return Array.from(new Set(values));
+    }
+
+    function updateMetricsFromContacts(target = data) {
+      if (!target || typeof target !== 'object') {
+        return;
+      }
+
+      if (!target.metrics || typeof target.metrics !== 'object') {
+        target.metrics = { ...defaultData.metrics };
+      }
+
+      const contacts = Array.isArray(target.contacts) ? target.contacts : [];
+      let emailCount = 0;
+      let phoneCount = 0;
+
+      contacts.forEach((contact) => {
+        if (!contact || typeof contact !== 'object') {
+          return;
+        }
+
+        const emailValue = contact.email ? contact.email.toString().trim() : '';
+        if (emailValue) {
+          emailCount += 1;
+        }
+
+        const mobileValue = contact.mobile ? contact.mobile.toString().trim() : '';
+        const landlineValue = contact.landline ? contact.landline.toString().trim() : '';
+        if (mobileValue) {
+          phoneCount += 1;
+        }
+        if (landlineValue) {
+          phoneCount += 1;
+        }
+      });
+
+      target.metrics.peopleCount = contacts.length;
+      target.metrics.emailCount = emailCount;
+      target.metrics.phoneCount = phoneCount;
+    }
+
+    function cleanupContactCategoryValues(target = data) {
+      if (!target || typeof target !== 'object') {
+        return;
+      }
+
+      const categoriesById = new Map(
+        Array.isArray(target.categories)
+          ? target.categories.map((category) => [category.id, category])
+          : [],
+      );
+
+      const contacts = Array.isArray(target.contacts) ? target.contacts : [];
+
+      contacts.forEach((contact) => {
+        if (!contact || typeof contact !== 'object') {
+          return;
+        }
+
+        const sourceValues =
+          contact.categoryValues && typeof contact.categoryValues === 'object'
+            ? contact.categoryValues
+            : {};
+        const cleanedValues = {};
+
+        Object.entries(sourceValues).forEach(([categoryId, rawValue]) => {
+          const category = categoriesById.get(categoryId);
+          if (!category) {
+            return;
+          }
+
+          const baseType = CATEGORY_TYPES.has(category.type) ? category.type : 'text';
+          if (rawValue === undefined || rawValue === null) {
+            return;
+          }
+
+          const valueString = rawValue.toString().trim();
+          if (!valueString) {
+            return;
+          }
+
+          if (baseType === 'number') {
+            const parsed = Number(valueString);
+            if (!Number.isFinite(parsed)) {
+              return;
+            }
+            cleanedValues[categoryId] = parsed.toString();
+            return;
+          }
+
+          if (baseType === 'list') {
+            const options = Array.isArray(category.options) ? category.options : [];
+            if (!options.includes(valueString)) {
+              return;
+            }
+          }
+
+          cleanedValues[categoryId] = valueString;
+        });
+
+        contact.categoryValues = cleanedValues;
+      });
     }
 
     function startKeywordEdition(keywordId) {
@@ -1587,6 +2243,23 @@
         }
       }
 
+      base.categories = base.categories
+        .filter((item) => item && typeof item === 'object')
+        .map((category) => {
+          const normalized = { ...category };
+          const typeValue = CATEGORY_TYPES.has(normalized.type) ? normalized.type : 'text';
+          normalized.type = typeValue;
+          if (typeValue === 'list') {
+            const optionValues = Array.isArray(normalized.options)
+              ? normalized.options.map((value) => (value != null ? value.toString().trim() : ''))
+              : [];
+            normalized.options = Array.from(new Set(optionValues.filter((value) => Boolean(value))));
+          } else {
+            normalized.options = [];
+          }
+          return normalized;
+        });
+
       if (!Array.isArray(base.keywords)) {
         base.keywords = [];
       }
@@ -1596,17 +2269,37 @@
       }
 
       base.contacts.forEach((contact) => {
-        if (!Array.isArray(contact.categories)) {
-          if (Array.isArray(contact.keywords)) {
-            contact.categories = contact.keywords.slice();
-          } else {
-            contact.categories = [];
-          }
+        if (!contact || typeof contact !== 'object') {
+          return;
         }
 
         if (!Array.isArray(contact.keywords)) {
           contact.keywords = [];
         }
+
+        const existingCategoryValues =
+          contact.categoryValues && typeof contact.categoryValues === 'object'
+            ? contact.categoryValues
+            : {};
+        const normalizedCategoryValues = {};
+
+        Object.entries(existingCategoryValues).forEach(([categoryId, rawValue]) => {
+          if (rawValue === undefined || rawValue === null) {
+            return;
+          }
+          normalizedCategoryValues[categoryId] = rawValue;
+        });
+
+        if (Array.isArray(contact.categories)) {
+          contact.categories.forEach((categoryId) => {
+            if (categoryId && !(categoryId in normalizedCategoryValues)) {
+              normalizedCategoryValues[categoryId] = 'Oui';
+            }
+          });
+        }
+
+        contact.categoryValues = normalizedCategoryValues;
+        delete contact.categories;
 
         if (!('mobile' in contact) && typeof contact.phone === 'string') {
           contact.mobile = contact.phone;
@@ -1638,6 +2331,9 @@
           }
         }
       });
+
+      cleanupContactCategoryValues(base);
+      updateMetricsFromContacts(base);
 
       if (!('lastUpdated' in base)) {
         base.lastUpdated = null;
@@ -1972,8 +2668,16 @@
     categoriesContainer.className = 'contact-categories';
     const keywordsContainer = document.createElement('div');
     keywordsContainer.className = 'contact-keywords';
+    const actionsContainer = document.createElement('div');
+    actionsContainer.className = 'contact-actions';
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'contact-action-button';
+    editButton.dataset.action = 'edit-contact';
+    editButton.textContent = 'Modifier';
+    actionsContainer.appendChild(editButton);
 
-    listItem.append(header, details, categoriesContainer, keywordsContainer);
+    listItem.append(header, details, categoriesContainer, keywordsContainer, actionsContainer);
     return listItem;
   }
 
@@ -1987,7 +2691,9 @@
     titleEl.className = 'category-title';
     const descriptionEl = document.createElement('p');
     descriptionEl.className = 'category-description';
-    categoryMain.append(titleEl, descriptionEl);
+    const metaEl = document.createElement('p');
+    metaEl.className = 'category-meta';
+    categoryMain.append(titleEl, descriptionEl, metaEl);
 
     const actions = document.createElement('div');
     actions.className = 'category-actions';

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -441,6 +441,13 @@ button {
   font-size: 0.9rem;
 }
 
+.form-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
 .checkbox-grid {
   display: grid;
   gap: 12px;
@@ -618,6 +625,26 @@ button {
   gap: 8px;
 }
 
+.contact-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.contact-action-button {
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.12);
+  transition: filter 0.2s ease;
+}
+
+.contact-action-button:hover {
+  filter: brightness(0.95);
+}
+
 .category-chip,
 .keyword-chip {
   display: inline-flex;
@@ -674,6 +701,12 @@ button {
 .keyword-description--empty {
   font-style: italic;
   color: rgba(71, 85, 105, 0.72);
+}
+
+.category-meta {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.85rem;
 }
 
 .category-actions,

--- a/dashboard.html
+++ b/dashboard.html
@@ -185,6 +185,26 @@
                 rows="3"
               ></textarea>
             </div>
+            <div class="form-row">
+              <label for="category-type">Type de valeur *</label>
+              <select id="category-type" name="category-type" required>
+                <option value="text" selected>Texte</option>
+                <option value="number">Nombre</option>
+                <option value="date">Date</option>
+                <option value="list">Liste</option>
+              </select>
+            </div>
+            <div class="form-row" id="category-options-row" hidden>
+              <label for="category-options">Liste de valeurs</label>
+              <textarea
+                id="category-options"
+                name="category-options"
+                rows="3"
+                maxlength="500"
+                placeholder="Saisissez une valeur par ligne"
+              ></textarea>
+              <p class="form-hint">Ces valeurs seront proposées lors de la saisie du contact.</p>
+            </div>
             <button type="submit" class="primary-button">Ajouter la catégorie</button>
           </form>
           <div class="category-list-wrapper">
@@ -456,11 +476,11 @@
               </div>
             </div>
             <fieldset id="contact-categories-fieldset" class="form-fieldset">
-              <legend>Catégories associées</legend>
+              <legend>Données personnalisées</legend>
               <p class="form-hint">
-                Sélectionnez une ou plusieurs catégories créées dans l’onglet «&nbsp;Catégories&nbsp;».
+                Renseignez les valeurs associées à chaque catégorie créée dans l’onglet «&nbsp;Catégories&nbsp;».
               </p>
-              <div id="contact-categories-container" class="checkbox-grid" aria-live="polite"></div>
+              <div id="contact-category-fields" class="form-grid" aria-live="polite"></div>
               <p id="contact-categories-empty" class="empty-state" hidden>
                 Aucune catégorie disponible pour le moment. Ajoutez vos catégories dans l’onglet «&nbsp;Catégories&nbsp;».
               </p>
@@ -485,7 +505,14 @@
                 placeholder="Informations complémentaires (optionnel)."
               ></textarea>
             </div>
-            <button type="submit" class="primary-button">Ajouter le contact</button>
+            <div class="form-actions">
+              <button type="submit" class="primary-button" id="contact-submit-button">
+                Ajouter le contact
+              </button>
+              <button type="button" class="secondary-button" id="contact-cancel-edit" hidden>
+                Annuler la modification
+              </button>
+            </div>
           </form>
         </section>
         <section id="contacts-search" class="page" aria-labelledby="contacts-search-title">
@@ -653,6 +680,11 @@
         </div>
         <div class="contact-categories"></div>
         <div class="contact-keywords"></div>
+        <div class="contact-actions">
+          <button type="button" class="contact-action-button" data-action="edit-contact">
+            Modifier
+          </button>
+        </div>
       </li>
     </template>
     <template id="category-item-template">
@@ -660,6 +692,7 @@
         <div class="category-main">
           <h3 class="category-title"></h3>
           <p class="category-description"></p>
+          <p class="category-meta"></p>
         </div>
         <div class="category-actions">
           <button type="button" class="category-button" data-action="edit">Modifier</button>


### PR DESCRIPTION
## Summary
- add category type selection with optional predefined list values and surface the type in listings
- rework the contact form to render typed fields per category, persist category values and allow editing contacts from the search results
- derive dashboard metrics directly from stored contacts and migrate existing data to the new category/value structure
- ensure the dashboard initializes after the category type constants are defined so stored data upgrades no longer throw and lock the navigation

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68cb2151433c832686e307d1851c8efa