### PR TITLE
Add contact deletion and category reordering UX improvements

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -735,6 +735,15 @@ button {
   filter: brightness(0.95);
 }
 
+.contact-action-button--danger {
+  color: #fff;
+  background: rgba(220, 38, 38, 0.9);
+}
+
+.contact-action-button--danger:hover {
+  filter: brightness(0.92);
+}
+
 .category-chip,
 .keyword-chip {
   display: inline-flex;
@@ -764,14 +773,52 @@ button {
   display: flex;
   gap: 20px;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: stretch;
   box-shadow: var(--shadow-card);
   border: 1px solid rgba(15, 23, 42, 0.05);
 }
 
 .category-main,
 .keyword-main {
+  flex: 1 1 auto;
   max-width: 640px;
+}
+
+.category-drag-handle {
+  align-self: stretch;
+  border: none;
+  background: transparent;
+  cursor: grab;
+  color: var(--color-text-secondary);
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s ease;
+}
+
+.category-drag-handle:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.category-drag-handle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.category-item.dragging {
+  opacity: 0.6;
+}
+
+.category-item.dragging .category-drag-handle {
+  cursor: grabbing;
+}
+
+.category-item.editing .category-drag-handle {
+  display: none;
 }
 
 .category-title,

--- a/dashboard.html
+++ b/dashboard.html
@@ -312,6 +312,9 @@
               <button type="submit" class="primary-button" id="contact-submit-button">
                 Ajouter le contact
               </button>
+              <button type="button" class="secondary-button" id="contact-back-to-search" hidden>
+                Retour à la recherche
+              </button>
               <button type="button" class="secondary-button" id="contact-cancel-edit" hidden>
                 Annuler la modification
               </button>
@@ -380,11 +383,28 @@
           <button type="button" class="contact-action-button" data-action="edit-contact">
             Modifier
           </button>
+          <button
+            type="button"
+            class="contact-action-button contact-action-button--danger"
+            data-action="delete-contact"
+          >
+            Supprimer
+          </button>
         </div>
       </li>
     </template>
     <template id="category-item-template">
       <li class="category-item">
+        <button
+          type="button"
+          class="category-drag-handle"
+          data-drag-handle
+          aria-label="Réorganiser la catégorie"
+          title="Déplacer la catégorie"
+          draggable="true"
+        >
+          ⋮⋮
+        </button>
         <div class="category-main">
           <h3 class="category-title"></h3>
           <p class="category-description"></p>


### PR DESCRIPTION
## Summary
- add a delete action to search results that removes contacts and updates stored metrics
- support manual category ordering via drag-and-drop and persist the new order in the data set
- refresh the contact editing experience with a return button, modifier labels, and display names built from the first two categories

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb4dd5950883269bf86230874e9fb9