### PR TITLE
Add dashboard toolbar with calendar event management

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -246,6 +246,65 @@ button {
   display: flex;
 }
 
+.dashboard-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 18px 24px;
+  flex-wrap: wrap;
+}
+
+.dashboard-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.dashboard-toolbar-button:hover {
+  background: rgba(37, 99, 235, 0.16);
+  transform: translateY(-1px);
+}
+
+.dashboard-toolbar-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.dashboard-toolbar-button--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.dashboard-toolbar-button--primary:hover {
+  background: var(--color-primary-dark);
+}
+
+.dashboard-toolbar-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+@media (max-width: 960px) {
+  .dashboard-toolbar {
+    gap: 12px;
+  }
+
+  .dashboard-toolbar-button {
+    flex: 1 1 180px;
+    justify-content: center;
+  }
+}
+
 .page-header {
   display: flex;
   align-items: center;
@@ -1017,5 +1076,441 @@ button {
 
   .contact-search-controls select {
     max-width: 100%;
+  }
+}
+
+.calendar-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+  z-index: 1200;
+}
+
+.calendar-overlay--open {
+  display: flex;
+}
+
+.calendar-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.28);
+  width: min(1100px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.calendar-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.calendar-subtitle {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.calendar-close-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
+  font-size: 1.2rem;
+  font-weight: 700;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-close-button:hover {
+  background: rgba(15, 23, 42, 0.16);
+  transform: rotate(90deg);
+}
+
+.calendar-close-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.calendar-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 24px 20px;
+  border-bottom: 1px solid var(--color-border);
+  flex-wrap: wrap;
+}
+
+.calendar-view-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.calendar-view-button {
+  padding: 10px 18px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.calendar-view-button.active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.calendar-view-button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+.calendar-navigation {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.calendar-nav-button {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
+  font-weight: 700;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-nav-button:hover {
+  background: rgba(15, 23, 42, 0.16);
+  transform: translateY(-1px);
+}
+
+.calendar-nav-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.calendar-current-period {
+  font-weight: 600;
+  font-size: 1.05rem;
+  text-transform: capitalize;
+}
+
+.calendar-layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.calendar-main {
+  flex: 1;
+  padding: 24px;
+  overflow: auto;
+}
+
+.calendar-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-auto-rows: minmax(120px, 1fr);
+}
+
+.calendar-grid--week {
+  grid-auto-rows: minmax(160px, 1fr);
+}
+
+.calendar-day {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-day:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  transform: translateY(-2px);
+}
+
+.calendar-day:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.4);
+}
+
+.calendar-day--outside {
+  background: rgba(226, 232, 240, 0.5);
+  color: var(--color-text-secondary);
+}
+
+.calendar-day--selected {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.calendar-day-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.calendar-day-weekday {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.calendar-day-weekday--empty {
+  visibility: hidden;
+}
+
+.calendar-day-number {
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.calendar-event-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.calendar-event-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.calendar-event-chip--more {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text-secondary);
+}
+
+.calendar-side {
+  width: 320px;
+  border-left: 1px solid var(--color-border);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow: auto;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.calendar-selected-date h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  text-transform: capitalize;
+}
+
+.calendar-selected-date-summary {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.calendar-event-form {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.calendar-form-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.calendar-form-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.calendar-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.calendar-events-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.calendar-events-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.calendar-empty-state {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.calendar-event-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.calendar-event-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.calendar-event-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.calendar-event-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calendar-event-time {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.calendar-event-notes {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.calendar-event-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.calendar-event-delete {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  color: var(--color-danger);
+  padding: 6px 12px;
+  font-weight: 600;
+  background: rgba(220, 38, 38, 0.08);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.calendar-event-delete:hover {
+  background: rgba(220, 38, 38, 0.16);
+  border-color: rgba(220, 38, 38, 0.42);
+}
+
+@media (max-width: 1024px) {
+  .calendar-side {
+    width: 280px;
+  }
+}
+
+@media (max-width: 900px) {
+  .calendar-dialog {
+    max-height: 100vh;
+  }
+
+  .calendar-layout {
+    flex-direction: column;
+  }
+
+  .calendar-side {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid var(--color-border);
+    padding: 20px 24px;
+    max-height: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .calendar-grid {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .calendar-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .calendar-view-toggle {
+    width: 100%;
+  }
+
+  .calendar-view-button {
+    flex: 1;
+  }
+
+  .calendar-navigation {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 600px) {
+  .calendar-overlay {
+    padding: 0;
+  }
+
+  .calendar-dialog {
+    border-radius: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .calendar-main {
+    padding: 20px;
   }
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -48,6 +48,38 @@
       </aside>
       <main class="content">
         <section id="dashboard" class="page active" aria-labelledby="dashboard-title">
+          <div
+            class="dashboard-toolbar"
+            role="toolbar"
+            aria-label="Actions rapides du tableau de bord"
+          >
+            <button
+              id="dashboard-calendar-button"
+              class="dashboard-toolbar-button dashboard-toolbar-button--primary"
+              type="button"
+            >
+              <span class="dashboard-toolbar-icon" aria-hidden="true">📅</span>
+              <span>Calendrier</span>
+            </button>
+            <button
+              id="dashboard-shortcut-contacts"
+              class="dashboard-toolbar-button"
+              type="button"
+              data-shortcut-target="contacts-add"
+            >
+              <span class="dashboard-toolbar-icon" aria-hidden="true">➕</span>
+              <span>Ajouter un contact</span>
+            </button>
+            <button
+              id="dashboard-shortcut-categories"
+              class="dashboard-toolbar-button"
+              type="button"
+              data-shortcut-target="categories"
+            >
+              <span class="dashboard-toolbar-icon" aria-hidden="true">🗂️</span>
+              <span>Gérer les catégories</span>
+            </button>
+          </div>
           <header class="page-header">
             <div>
               <h1 id="dashboard-title">Tableau de bord</h1>
@@ -365,6 +397,127 @@
             Ajoutez vos premiers contacts pour les retrouver ici.
           </p>
         </section>
+        <div
+          id="calendar-overlay"
+          class="calendar-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="calendar-dialog-title"
+          aria-hidden="true"
+          hidden
+        >
+          <div class="calendar-dialog">
+            <header class="calendar-header">
+              <div>
+                <h2 id="calendar-dialog-title">Calendrier des évènements</h2>
+                <p class="calendar-subtitle">
+                  Planifiez vos actions et notez vos rendez-vous importants.
+                </p>
+              </div>
+              <button
+                id="calendar-close-button"
+                class="calendar-close-button"
+                type="button"
+                aria-label="Fermer le calendrier"
+              >
+                ✕
+              </button>
+            </header>
+            <div class="calendar-toolbar">
+              <div
+                class="calendar-view-toggle"
+                role="group"
+                aria-label="Changer la vue du calendrier"
+              >
+                <button
+                  type="button"
+                  class="calendar-view-button"
+                  data-calendar-view="week"
+                  aria-pressed="false"
+                >
+                  Semaine
+                </button>
+                <button
+                  type="button"
+                  class="calendar-view-button active"
+                  data-calendar-view="month"
+                  aria-pressed="true"
+                >
+                  Mois
+                </button>
+              </div>
+              <div class="calendar-navigation">
+                <button
+                  type="button"
+                  class="calendar-nav-button"
+                  data-calendar-nav="prev"
+                  aria-label="Période précédente"
+                >
+                  ◀
+                </button>
+                <span id="calendar-current-period" class="calendar-current-period">—</span>
+                <button
+                  type="button"
+                  class="calendar-nav-button"
+                  data-calendar-nav="next"
+                  aria-label="Période suivante"
+                >
+                  ▶
+                </button>
+              </div>
+            </div>
+            <div class="calendar-layout">
+              <div class="calendar-main">
+                <div id="calendar-grid" class="calendar-grid" role="grid" aria-live="polite"></div>
+              </div>
+              <aside class="calendar-side">
+                <div class="calendar-selected-date">
+                  <h3 id="calendar-selected-date-label">—</h3>
+                  <p id="calendar-selected-date-summary" class="calendar-selected-date-summary">
+                    Choisissez un jour pour afficher les détails.
+                  </p>
+                </div>
+                <form id="calendar-event-form" class="calendar-event-form">
+                  <h3 class="calendar-form-title">Nouvel évènement</h3>
+                  <div class="form-row">
+                    <label for="calendar-event-title">Titre *</label>
+                    <input id="calendar-event-title" name="title" type="text" required maxlength="120" />
+                  </div>
+                  <div class="calendar-form-row">
+                    <div class="form-row">
+                      <label for="calendar-event-date">Date *</label>
+                      <input id="calendar-event-date" name="date" type="date" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="calendar-event-time">Heure</label>
+                      <input id="calendar-event-time" name="time" type="time" />
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <label for="calendar-event-notes">Notes</label>
+                    <textarea
+                      id="calendar-event-notes"
+                      name="notes"
+                      rows="3"
+                      placeholder="Ajoutez des détails ou des objectifs."
+                    ></textarea>
+                  </div>
+                  <div class="calendar-form-actions">
+                    <button type="reset" class="secondary-button">Réinitialiser</button>
+                    <button type="submit" class="primary-button">Ajouter</button>
+                  </div>
+                </form>
+                <div class="calendar-events-wrapper">
+                  <h3 class="calendar-events-title">Évènements du jour</h3>
+                  <p id="calendar-event-empty" class="calendar-empty-state">
+                    Aucun évènement enregistré pour cette date.
+                  </p>
+                  <ul id="calendar-event-list" class="calendar-event-list"></ul>
+                </div>
+              </aside>
+            </div>
+          </div>
+        </div>
       </main>
     </div>
     <template id="contact-item-template">


### PR DESCRIPTION
## Summary
- add a quick action toolbar to the dashboard to surface the calendar and useful shortcuts
- implement a calendar dialog supporting weekly and monthly views with event creation and deletion persisted per user
- style the new toolbar and calendar so they blend into the existing design system

## Testing
- node --check assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68cbbcd8dfd48326bc1b04ce3dc1282d