### PR TITLE
Add task management panel to dashboard toolbar

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -294,6 +294,256 @@ button {
   line-height: 1;
 }
 
+.task-panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.task-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.task-panel-subtitle {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.task-count-badge {
+  align-self: flex-start;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 8px 14px;
+  font-size: 0.9rem;
+}
+
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.task-form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.task-form-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.task-members-select {
+  min-height: 120px;
+}
+
+.task-list-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.task-empty-state {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.task-item {
+  --task-color: var(--color-primary);
+  --task-color-soft: rgba(37, 99, 235, 0.08);
+  border: 1px solid var(--color-border);
+  border-left: 6px solid var(--task-color);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--task-color-soft);
+  box-shadow: var(--shadow-card);
+}
+
+.task-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.task-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.task-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  min-width: 180px;
+}
+
+.task-due-date {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.task-due-date::before {
+  content: '⏰';
+}
+
+.task-due-date--overdue {
+  color: var(--color-danger);
+}
+
+.task-members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.task-member-chip {
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.task-description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.task-description--empty {
+  font-style: italic;
+  color: var(--color-text-secondary);
+}
+
+.task-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.task-action-button {
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.task-action-button:hover {
+  background: rgba(15, 23, 42, 0.14);
+}
+
+.task-action-button--danger {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-danger);
+}
+
+.task-action-button--danger:hover {
+  background: rgba(220, 38, 38, 0.2);
+}
+
+.task-comments {
+  border-top: 1px solid var(--color-border);
+  padding-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-comments-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.task-comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.task-comment {
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.task-comment-meta {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.task-comment-content {
+  margin: 0;
+  line-height: 1.4;
+  color: var(--color-text);
+}
+
+.task-comment-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.task-comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.task-comment-form textarea {
+  min-height: 70px;
+}
+
+.task-comment-submit {
+  align-self: flex-end;
+}
+
 @media (max-width: 960px) {
   .dashboard-toolbar {
     gap: 12px;
@@ -302,6 +552,22 @@ button {
   .dashboard-toolbar-button {
     flex: 1 1 180px;
     justify-content: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .task-panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .task-meta {
+    align-items: flex-start;
+    min-width: auto;
+  }
+
+  .task-actions {
+    margin-left: 0;
   }
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -79,7 +79,89 @@
               <span class="dashboard-toolbar-icon" aria-hidden="true">🗂️</span>
               <span>Gérer les catégories</span>
             </button>
+            <button
+              id="dashboard-tasklist-button"
+              class="dashboard-toolbar-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="dashboard-task-panel"
+            >
+              <span class="dashboard-toolbar-icon" aria-hidden="true">✅</span>
+              <span>Liste des tâches</span>
+            </button>
           </div>
+          <section
+            id="dashboard-task-panel"
+            class="task-panel"
+            aria-labelledby="task-panel-title"
+            hidden
+          >
+            <header class="task-panel-header">
+              <div>
+                <h2 id="task-panel-title">Liste des tâches</h2>
+                <p id="task-panel-description" class="task-panel-subtitle">
+                  Centralisez vos actions et attribuez-les aux membres de l'équipe.
+                </p>
+              </div>
+              <span id="task-count-badge" class="task-count-badge" aria-live="polite">0 tâche</span>
+            </header>
+            <form id="task-form" class="task-form" autocomplete="off">
+              <div class="task-form-grid">
+                <div class="form-row">
+                  <label for="task-title">Titre de la tâche *</label>
+                  <input
+                    id="task-title"
+                    name="task-title"
+                    type="text"
+                    required
+                    maxlength="140"
+                    placeholder="Ex. Relancer les partenaires, préparer un dossier"
+                  />
+                </div>
+                <div class="form-row">
+                  <label for="task-due-date">Date limite</label>
+                  <input id="task-due-date" name="task-due-date" type="date" />
+                </div>
+                <div class="form-row">
+                  <label for="task-color">Couleur</label>
+                  <input id="task-color" name="task-color" type="color" value="#2563eb" />
+                </div>
+              </div>
+              <div class="form-row">
+                <label for="task-members">Attribuer à</label>
+                <select
+                  id="task-members"
+                  name="task-members"
+                  class="task-members-select"
+                  multiple
+                  aria-describedby="task-members-hint"
+                ></select>
+                <p id="task-members-hint" class="form-hint">
+                  Maintenez la touche Ctrl (ou Cmd sur Mac) pour sélectionner plusieurs membres.
+                </p>
+              </div>
+              <div class="form-row">
+                <label for="task-description">Description</label>
+                <textarea
+                  id="task-description"
+                  name="task-description"
+                  rows="3"
+                  maxlength="500"
+                  placeholder="Précisez les objectifs ou les étapes à suivre (optionnel)."
+                ></textarea>
+              </div>
+              <div class="task-form-actions">
+                <button type="submit" class="primary-button">Ajouter la tâche</button>
+                <button type="reset" class="secondary-button">Réinitialiser</button>
+              </div>
+            </form>
+            <div class="task-list-wrapper">
+              <ul id="task-list" class="task-list" aria-live="polite"></ul>
+              <p id="task-empty-state" class="task-empty-state">
+                Aucune tâche planifiée pour le moment. Ajoutez votre première action ci-dessus.
+              </p>
+            </div>
+          </section>
           <header class="page-header">
             <div>
               <h1 id="dashboard-title">Tableau de bord</h1>


### PR DESCRIPTION
## Summary
- add a task list toggle to the dashboard toolbar with a management panel for creating and viewing tasks
- style the task management interface, task cards, and comment section to match the dashboard aesthetic
- persist task data (including assignees and comments) alongside existing user data with normalization and sorting helpers

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cbc1d03bb883269195114ce6b54da4