### PR TITLE
Add Excel contact import workflow

### DIFF
--- a/assets/importContacts.js
+++ b/assets/importContacts.js
@@ -1,0 +1,680 @@
+(() => {
+  const PREVIEW_LIMIT = 5;
+  const CATEGORY_TYPE_LABELS = {
+    text: 'Texte',
+    number: 'Nombre',
+    date: 'Date',
+    list: 'Liste',
+  };
+  const numberFormatter = new Intl.NumberFormat('fr-FR');
+  const XLSX_ERROR_MESSAGE =
+    "L’import de fichiers Excel est indisponible. Vérifiez votre connexion internet.";
+
+  function columnIndexToLetter(index) {
+    let result = '';
+    let current = index;
+    while (current >= 0) {
+      result = String.fromCharCode((current % 26) + 65) + result;
+      current = Math.floor(current / 26) - 1;
+    }
+    return result || 'A';
+  }
+
+  function formatCategoryType(type) {
+    const normalized = typeof type === 'string' ? type.toLowerCase() : 'text';
+    return CATEGORY_TYPE_LABELS[normalized] || CATEGORY_TYPE_LABELS.text;
+  }
+
+  function getImportApi() {
+    if (typeof window !== 'undefined' && window.UManager && window.UManager.importApi) {
+      return window.UManager.importApi;
+    }
+    return null;
+  }
+
+  function buildColumnsMetadata(rows) {
+    const maxColumns = rows.reduce((max, row) => {
+      if (!Array.isArray(row)) {
+        return max;
+      }
+      return Math.max(max, row.length);
+    }, 0);
+
+    const columns = [];
+    for (let index = 0; index < maxColumns; index += 1) {
+      const letter = columnIndexToLetter(index);
+      const headerRow = Array.isArray(rows[0]) ? rows[0] : [];
+      const headerValue = headerRow[index];
+      const header =
+        headerValue === undefined || headerValue === null
+          ? ''
+          : headerValue.toString().trim();
+
+      const samples = [];
+      for (let rowIndex = 1; rowIndex < rows.length && samples.length < 3; rowIndex += 1) {
+        const row = Array.isArray(rows[rowIndex]) ? rows[rowIndex] : [];
+        const cellValue = row[index];
+        const valueString =
+          cellValue === undefined || cellValue === null ? '' : cellValue.toString().trim();
+        if (valueString && !samples.includes(valueString)) {
+          samples.push(valueString);
+        }
+      }
+
+      columns.push({ index, letter, header, samples });
+    }
+    return columns;
+  }
+
+  function getCategories() {
+    const api = getImportApi();
+    if (!api || typeof api.getCategories !== 'function') {
+      return [];
+    }
+
+    try {
+      const categories = api.getCategories();
+      if (!Array.isArray(categories)) {
+        return [];
+      }
+      return categories
+        .map((category) => ({
+          id: category && category.id ? category.id : '',
+          name: category && category.name ? category.name : '',
+          type: category && category.type ? category.type : 'text',
+          options: Array.isArray(category && category.options) ? category.options : [],
+        }))
+        .filter((category) => Boolean(category.id));
+    } catch (error) {
+      console.warn('Impossible de récupérer les catégories pour l’import :', error);
+      return [];
+    }
+  }
+
+  function getErrorSummaries(errors) {
+    if (!Array.isArray(errors)) {
+      return [];
+    }
+
+    return errors.map((error) => {
+      const rowNumber = Number(error && error.row);
+      const rowLabel = Number.isFinite(rowNumber) && rowNumber > 0
+        ? `Ligne ${numberFormatter.format(rowNumber)}`
+        : 'Ligne inconnue';
+      const message = error && error.message ? error.message : 'Valeur non reconnue.';
+      return `${rowLabel} — ${message}`;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const importPage = document.getElementById('contacts-import');
+    if (!importPage) {
+      return;
+    }
+
+    const fileInput = document.getElementById('contact-import-file');
+    const fileSummaryEl = document.getElementById('contact-import-file-summary');
+    const optionsSection = document.getElementById('contact-import-options');
+    const mappingContainer = document.getElementById('contact-import-mapping');
+    const mappingEmptyEl = document.getElementById('contact-import-mapping-empty');
+    const hasHeaderCheckbox = document.getElementById('contact-import-has-header');
+    const feedbackEl = document.getElementById('contact-import-feedback');
+    const importButton = document.getElementById('contact-import-submit');
+    const resetButton = document.getElementById('contact-import-reset');
+    const previewSection = document.getElementById('contact-import-preview');
+    const previewTable = previewSection
+      ? previewSection.querySelector('.import-preview-table')
+      : null;
+    const previewHead = previewTable ? previewTable.querySelector('thead') : null;
+    const previewBody = previewTable ? previewTable.querySelector('tbody') : null;
+    const summaryCountEl = document.getElementById('contact-import-summary-count');
+
+    if (
+      !(fileInput instanceof HTMLInputElement) ||
+      !(importButton instanceof HTMLButtonElement) ||
+      !mappingContainer
+    ) {
+      return;
+    }
+
+    const state = {
+      rows: [],
+      columns: [],
+      mapping: new Map(),
+      fileName: '',
+      sheetName: '',
+      skipHeader: true,
+    };
+
+    function resetFeedback() {
+      if (!feedbackEl) {
+        return;
+      }
+      feedbackEl.innerHTML = '';
+      feedbackEl.classList.remove(
+        'import-feedback--success',
+        'import-feedback--error',
+        'import-feedback--warning',
+      );
+    }
+
+    function showFeedback(message, type = 'info', details) {
+      if (!feedbackEl) {
+        return;
+      }
+      resetFeedback();
+      if (type === 'success') {
+        feedbackEl.classList.add('import-feedback--success');
+      } else if (type === 'error') {
+        feedbackEl.classList.add('import-feedback--error');
+      } else if (type === 'warning') {
+        feedbackEl.classList.add('import-feedback--warning');
+      }
+
+      const text = document.createElement('p');
+      text.textContent = message;
+      feedbackEl.appendChild(text);
+
+      if (Array.isArray(details) && details.length > 0) {
+        const list = document.createElement('ul');
+        list.className = 'import-feedback-list';
+        details.slice(0, 3).forEach((detail) => {
+          const item = document.createElement('li');
+          item.textContent = detail;
+          list.appendChild(item);
+        });
+        feedbackEl.appendChild(list);
+
+        if (details.length > 3) {
+          const more = document.createElement('p');
+          more.className = 'import-feedback-more';
+          const remaining = details.length - 3;
+          more.textContent = `+ ${numberFormatter.format(remaining)} autre${
+            remaining > 1 ? 's' : ''
+          } à vérifier.`;
+          feedbackEl.appendChild(more);
+        }
+      }
+    }
+
+    function updateOptionsVisibility() {
+      if (!optionsSection) {
+        return;
+      }
+      optionsSection.hidden = state.rows.length === 0;
+    }
+
+    function updateSummaryCount() {
+      if (!summaryCountEl) {
+        return;
+      }
+      if (state.rows.length === 0) {
+        summaryCountEl.textContent = '—';
+        return;
+      }
+      const startIndex = state.skipHeader ? 1 : 0;
+      const count = Math.max(state.rows.length - startIndex, 0);
+      summaryCountEl.textContent = numberFormatter.format(count);
+    }
+
+    function clearPreview() {
+      if (!previewSection || !previewHead || !previewBody) {
+        return;
+      }
+      previewSection.hidden = true;
+      previewHead.innerHTML = '';
+      previewBody.innerHTML = '';
+    }
+
+    function renderFileSummary() {
+      if (!fileSummaryEl) {
+        return;
+      }
+
+      if (state.rows.length === 0) {
+        fileSummaryEl.hidden = true;
+        fileSummaryEl.textContent = '';
+        return;
+      }
+
+      const totalRows = state.rows.length;
+      const totalColumns = state.columns.length;
+      const sheetInfo = state.sheetName ? ` · Feuille « ${state.sheetName} »` : '';
+      fileSummaryEl.hidden = false;
+      fileSummaryEl.textContent = `${state.fileName || 'Fichier'} — ${numberFormatter.format(
+        totalColumns,
+      )} ${totalColumns > 1 ? 'colonnes' : 'colonne'}, ${numberFormatter.format(
+        totalRows,
+      )} ${totalRows > 1 ? 'lignes' : 'ligne'}${sheetInfo}.`;
+    }
+
+    function renderPreview() {
+      if (!previewSection || !previewHead || !previewBody) {
+        return;
+      }
+
+      if (state.rows.length === 0 || state.columns.length === 0) {
+        clearPreview();
+        return;
+      }
+
+      previewHead.innerHTML = '';
+      previewBody.innerHTML = '';
+
+      const headerRow = document.createElement('tr');
+      state.columns.forEach((column) => {
+        const th = document.createElement('th');
+        const labelParts = [column.letter];
+        if (column.header) {
+          labelParts.push(`— ${column.header}`);
+        }
+        th.textContent = labelParts.join(' ');
+        headerRow.appendChild(th);
+      });
+      previewHead.appendChild(headerRow);
+
+      const startIndex = state.skipHeader ? 1 : 0;
+      const sampleRows = state.rows.slice(startIndex, startIndex + PREVIEW_LIMIT);
+
+      if (sampleRows.length === 0) {
+        const emptyRow = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = Math.max(state.columns.length, 1);
+        cell.textContent = 'Aucune ligne à afficher avec la configuration actuelle.';
+        emptyRow.appendChild(cell);
+        previewBody.appendChild(emptyRow);
+        previewSection.hidden = false;
+        return;
+      }
+
+      sampleRows.forEach((row) => {
+        const tr = document.createElement('tr');
+        state.columns.forEach((column) => {
+          const td = document.createElement('td');
+          const value = Array.isArray(row) ? row[column.index] : undefined;
+          td.textContent = value === undefined || value === null ? '' : value.toString();
+          tr.appendChild(td);
+        });
+        previewBody.appendChild(tr);
+      });
+
+      previewSection.hidden = false;
+    }
+
+    function updateActionsState(categoriesList) {
+      const categories = Array.isArray(categoriesList) ? categoriesList : getCategories();
+      const hasRows = state.rows.length > 0;
+      const hasColumns = state.columns.length > 0;
+      const hasCategories = categories.length > 0;
+      const hasMapping = hasRows
+        ? Array.from(state.mapping.values()).some((value) => Number.isInteger(value) && value >= 0)
+        : false;
+
+      importButton.disabled = !(hasRows && hasColumns && hasCategories && hasMapping);
+      if (resetButton instanceof HTMLButtonElement) {
+        resetButton.disabled = !hasRows;
+      }
+    }
+
+    function renderCategoryMapping() {
+      if (!mappingContainer) {
+        return;
+      }
+
+      mappingContainer.innerHTML = '';
+      if (mappingEmptyEl) {
+        mappingEmptyEl.hidden = true;
+      }
+
+      if (state.rows.length === 0) {
+        updateActionsState([]);
+        return;
+      }
+
+      if (state.columns.length === 0) {
+        if (mappingEmptyEl) {
+          mappingEmptyEl.hidden = false;
+          mappingEmptyEl.textContent =
+            'Aucune colonne exploitable n’a été détectée dans ce fichier Excel.';
+        }
+        updateActionsState([]);
+        return;
+      }
+
+      const categories = getCategories();
+      const allowedIds = new Set(categories.map((category) => category.id));
+      Array.from(state.mapping.keys()).forEach((categoryId) => {
+        if (!allowedIds.has(categoryId)) {
+          state.mapping.delete(categoryId);
+        }
+      });
+
+      if (categories.length === 0) {
+        if (mappingEmptyEl) {
+          mappingEmptyEl.hidden = false;
+          mappingEmptyEl.textContent =
+            'Ajoutez vos catégories dans l’onglet « Catégories » pour pouvoir importer vos contacts.';
+        }
+        updateActionsState(categories);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      categories.forEach((category) => {
+        const row = document.createElement('div');
+        row.className = 'import-mapping-row';
+
+        const label = document.createElement('div');
+        label.className = 'import-mapping-label';
+
+        const title = document.createElement('strong');
+        title.textContent = category.name || 'Catégorie';
+        label.appendChild(title);
+
+        const meta = document.createElement('span');
+        meta.className = 'import-mapping-meta';
+        meta.textContent = `Type : ${formatCategoryType(category.type)}`;
+        label.appendChild(meta);
+
+        const select = document.createElement('select');
+        select.className = 'import-mapping-select';
+        select.dataset.categoryId = category.id;
+
+        const noneOption = document.createElement('option');
+        noneOption.value = '';
+        noneOption.textContent = 'Ne pas importer';
+        select.appendChild(noneOption);
+
+        state.columns.forEach((column) => {
+          const option = document.createElement('option');
+          option.value = column.index.toString();
+          const labelParts = [column.letter];
+          if (column.header) {
+            labelParts.push(`— ${column.header}`);
+          }
+          if (column.samples.length > 0) {
+            labelParts.push(`(ex. ${column.samples.slice(0, 2).join(', ')})`);
+          }
+          option.textContent = labelParts.join(' ');
+          if (state.mapping.get(category.id) === column.index) {
+            option.selected = true;
+          }
+          select.appendChild(option);
+        });
+
+        select.addEventListener('change', handleMappingChange);
+
+        row.append(label, select);
+        fragment.appendChild(row);
+      });
+
+      mappingContainer.appendChild(fragment);
+      updateActionsState(categories);
+    }
+
+    function handleMappingChange(event) {
+      const select = event.currentTarget;
+      if (!(select instanceof HTMLSelectElement)) {
+        return;
+      }
+      const categoryId = select.dataset.categoryId || '';
+      if (!categoryId) {
+        return;
+      }
+
+      const value = select.value;
+      if (!value) {
+        state.mapping.delete(categoryId);
+        updateActionsState();
+        return;
+      }
+
+      const parsed = Number(value);
+      if (Number.isInteger(parsed) && parsed >= 0) {
+        state.mapping.set(categoryId, parsed);
+      } else {
+        state.mapping.delete(categoryId);
+      }
+      updateActionsState();
+    }
+
+    function synchronizeView() {
+      renderFileSummary();
+      updateOptionsVisibility();
+      renderCategoryMapping();
+      renderPreview();
+      updateSummaryCount();
+      updateActionsState();
+    }
+
+    function handleHeaderToggle() {
+      if (!(hasHeaderCheckbox instanceof HTMLInputElement)) {
+        return;
+      }
+      state.skipHeader = hasHeaderCheckbox.checked;
+      renderPreview();
+      updateSummaryCount();
+    }
+
+    function resetState(options = {}) {
+      const keepFileInput = Boolean(options.keepFileInput);
+      state.rows = [];
+      state.columns = [];
+      state.mapping.clear();
+      state.fileName = '';
+      state.sheetName = '';
+      state.skipHeader = true;
+
+      if (!keepFileInput) {
+        fileInput.value = '';
+      }
+      if (hasHeaderCheckbox instanceof HTMLInputElement) {
+        hasHeaderCheckbox.checked = true;
+      }
+      if (fileSummaryEl) {
+        fileSummaryEl.hidden = true;
+        fileSummaryEl.textContent = '';
+      }
+      if (mappingEmptyEl) {
+        mappingEmptyEl.hidden = true;
+      }
+      mappingContainer.innerHTML = '';
+      clearPreview();
+      updateOptionsVisibility();
+      updateSummaryCount();
+      updateActionsState();
+    }
+
+    async function handleImportClick() {
+      const api = getImportApi();
+      if (!api || typeof api.importContacts !== 'function') {
+        showFeedback("L’importation est indisponible pour le moment.", 'error');
+        return;
+      }
+      if (state.rows.length === 0 || state.columns.length === 0) {
+        showFeedback('Veuillez sélectionner un fichier Excel avant de lancer l’import.', 'warning');
+        return;
+      }
+      const mappingEntries = Array.from(state.mapping.entries()).filter(([, value]) =>
+        Number.isInteger(value) && value >= 0,
+      );
+      if (mappingEntries.length === 0) {
+        showFeedback('Associez au moins une catégorie à une colonne pour lancer l’import.', 'warning');
+        return;
+      }
+
+      importButton.disabled = true;
+      showFeedback('Import des contacts en cours…', 'info');
+
+      try {
+        const payload = {
+          rows: state.rows,
+          mapping: Object.fromEntries(mappingEntries),
+          skipHeader: state.skipHeader,
+          fileName: state.fileName,
+        };
+        const result = await Promise.resolve(api.importContacts(payload));
+        const importedCountRaw =
+          result && result.importedCount != null ? Number(result.importedCount) : 0;
+        const skippedRaw =
+          result && result.skippedEmptyCount != null ? Number(result.skippedEmptyCount) : 0;
+        const errorRaw = result && result.errorCount != null ? Number(result.errorCount) : 0;
+        const importedCount = Number.isFinite(importedCountRaw) ? importedCountRaw : 0;
+        const skippedEmptyCount = Number.isFinite(skippedRaw) ? skippedRaw : 0;
+        const errorCount = Number.isFinite(errorRaw) ? errorRaw : 0;
+        const summaryParts = [];
+        if (importedCount > 0) {
+          summaryParts.push(
+            `${numberFormatter.format(importedCount)} contact${importedCount > 1 ? 's' : ''} importé${
+              importedCount > 1 ? 's' : ''
+            }`,
+          );
+        }
+        if (skippedEmptyCount > 0) {
+          summaryParts.push(
+            `${numberFormatter.format(skippedEmptyCount)} ligne${
+              skippedEmptyCount > 1 ? 's' : ''
+            } ignorée${skippedEmptyCount > 1 ? 's' : ''}`,
+          );
+        }
+        if (errorCount > 0) {
+          summaryParts.push(
+            `${numberFormatter.format(errorCount)} ligne${errorCount > 1 ? 's' : ''} à corriger`,
+          );
+        }
+        if (summaryParts.length === 0) {
+          summaryParts.push('Aucun nouveau contact importé.');
+        }
+
+        let feedbackType = 'success';
+        if (importedCount === 0) {
+          feedbackType = errorCount > 0 ? 'error' : 'warning';
+        } else if (errorCount > 0 || skippedEmptyCount > 0) {
+          feedbackType = 'warning';
+        }
+
+        const errorSummaries = getErrorSummaries(result && result.errors);
+        showFeedback(summaryParts.join(' · '), feedbackType, errorSummaries);
+      } catch (error) {
+        console.error('Erreur lors de l’import des contacts :', error);
+        showFeedback('Une erreur est survenue lors de l’importation des contacts.', 'error');
+      } finally {
+        updateActionsState();
+      }
+    }
+
+    function handleReset() {
+      resetState();
+      showFeedback('Sélectionnez un fichier Excel pour commencer.', 'info');
+    }
+
+    function handlePageChanged(event) {
+      if (!event || !event.detail) {
+        return;
+      }
+      if (event.detail.pageId === 'contacts-import') {
+        synchronizeView();
+      }
+    }
+
+    async function handleFileChange() {
+      if (!fileInput.files || fileInput.files.length === 0) {
+        resetState({ keepFileInput: true });
+        showFeedback('Sélectionnez un fichier Excel pour commencer.', 'info');
+        return;
+      }
+
+      const file = fileInput.files[0];
+      showFeedback(`Analyse de « ${file.name} » en cours…`, 'info');
+
+      try {
+        const { rows, sheetName } = await loadWorkbook(file);
+        state.rows = Array.isArray(rows) ? rows : [];
+        state.columns = buildColumnsMetadata(state.rows);
+        state.mapping.clear();
+        state.fileName = file.name || '';
+        state.sheetName = sheetName || '';
+        state.skipHeader = true;
+        if (hasHeaderCheckbox instanceof HTMLInputElement) {
+          hasHeaderCheckbox.checked = true;
+        }
+
+        synchronizeView();
+
+        if (state.rows.length === 0) {
+          showFeedback('Le fichier ne contient aucune donnée exploitable.', 'warning');
+        } else {
+          showFeedback('Fichier analysé. Associez vos catégories aux colonnes détectées.', 'success');
+        }
+      } catch (error) {
+        console.error('Impossible de lire le fichier importé :', error);
+        resetState();
+        showFeedback(
+          'Impossible de lire ce fichier. Vérifiez qu’il s’agit bien d’un fichier Excel valide.',
+          'error',
+        );
+      }
+    }
+
+    function loadWorkbook(file) {
+      return new Promise((resolve, reject) => {
+        if (!window.XLSX || typeof window.XLSX.read !== 'function') {
+          reject(new Error('Bibliothèque XLSX indisponible.'));
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onerror = () => {
+          reject(new Error('Lecture du fichier impossible.'));
+        };
+        reader.onload = () => {
+          try {
+            const workbook = window.XLSX.read(reader.result, { type: 'array', raw: false });
+            const sheetName = workbook.SheetNames[0];
+            if (!sheetName) {
+              resolve({ rows: [], sheetName: '' });
+              return;
+            }
+            const sheet = workbook.Sheets[sheetName];
+            const rows = window.XLSX.utils.sheet_to_json(sheet, {
+              header: 1,
+              raw: false,
+              blankrows: true,
+              defval: '',
+            });
+            resolve({ rows, sheetName });
+          } catch (error) {
+            reject(error);
+          }
+        };
+        reader.readAsArrayBuffer(file);
+      });
+    }
+
+    if (!window.XLSX || typeof window.XLSX.read !== 'function') {
+      fileInput.disabled = true;
+      importButton.disabled = true;
+      if (resetButton instanceof HTMLButtonElement) {
+        resetButton.disabled = true;
+      }
+      showFeedback(XLSX_ERROR_MESSAGE, 'error');
+      return;
+    }
+
+    fileInput.addEventListener('change', handleFileChange);
+    if (hasHeaderCheckbox instanceof HTMLInputElement) {
+      hasHeaderCheckbox.addEventListener('change', handleHeaderToggle);
+    }
+    importButton.addEventListener('click', handleImportClick);
+    if (resetButton instanceof HTMLButtonElement) {
+      resetButton.addEventListener('click', handleReset);
+    }
+
+    document.addEventListener('umanager:page-changed', handlePageChanged);
+
+    synchronizeView();
+    if (state.rows.length === 0) {
+      showFeedback('Sélectionnez un fichier Excel pour commencer.', 'info');
+    }
+  });
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1715,6 +1715,182 @@ button {
   border-color: rgba(220, 38, 38, 0.42);
 }
 
+/* Import de contacts */
+.import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.import-file-summary {
+  padding: 12px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.import-options {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.import-header-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.import-header-toggle input {
+  transform: scale(1.05);
+}
+
+.import-mapping {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.import-mapping-row {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+.import-mapping-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.import-mapping-label strong {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.import-mapping-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.import-mapping-select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.import-mapping-select:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.35);
+  border-color: rgba(37, 99, 235, 0.5);
+}
+
+.import-feedback {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: 14px 16px;
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.import-feedback--success {
+  border-color: rgba(16, 185, 129, 0.35);
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.import-feedback--error {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-danger);
+}
+
+.import-feedback--warning {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+}
+
+.import-feedback-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.import-feedback-more {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.import-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.import-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.import-preview-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.import-preview-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.import-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.import-preview-table th,
+.import-preview-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  font-size: 0.9rem;
+  text-align: left;
+  color: var(--color-text);
+}
+
+.import-preview-table th {
+  background: rgba(37, 99, 235, 0.12);
+  font-weight: 600;
+}
+
+.import-preview-table tr:last-child td {
+  border-bottom: none;
+}
+
 @media (max-width: 1024px) {
   .calendar-side {
     width: 280px;
@@ -1742,6 +1918,14 @@ button {
 @media (max-width: 720px) {
   .calendar-grid {
     gap: 8px;
+  }
+
+  .import-mapping {
+    grid-template-columns: 1fr;
+  }
+
+  .import-preview-table {
+    min-width: 100%;
   }
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -30,6 +30,9 @@
           <button class="nav-button" data-target="contacts-add" type="button">
             Ajouter des contacts
           </button>
+          <button class="nav-button" data-target="contacts-import" type="button">
+            Importer des contacts
+          </button>
           <button class="nav-button" data-target="contacts-search" type="button">
             Recherche de contact
           </button>
@@ -371,6 +374,62 @@
               </button>
             </div>
           </form>
+        </section>
+        <section id="contacts-import" class="page" aria-labelledby="contacts-import-title">
+          <header class="page-header">
+            <div>
+              <h1 id="contacts-import-title">Importer des contacts</h1>
+              <p class="page-subtitle">
+                Téléchargez un fichier Excel puis associez ses colonnes à vos catégories personnalisées.
+              </p>
+            </div>
+            <div class="insight-card">
+              <span class="insight-label">Contacts détectés</span>
+              <span class="insight-value" id="contact-import-summary-count">—</span>
+            </div>
+          </header>
+          <form id="contact-import-form" class="import-form" autocomplete="off">
+            <div class="form-row">
+              <label for="contact-import-file">Fichier Excel à importer</label>
+              <input id="contact-import-file" type="file" accept=".xlsx,.xls,.csv" />
+              <p class="form-hint">
+                Le traitement s’effectue entièrement dans votre navigateur&nbsp;: aucun fichier n’est envoyé sur un
+                serveur externe.
+              </p>
+            </div>
+            <div id="contact-import-file-summary" class="import-file-summary" hidden></div>
+            <div id="contact-import-options" class="import-options" hidden>
+              <label class="import-header-toggle" for="contact-import-has-header">
+                <input type="checkbox" id="contact-import-has-header" checked />
+                Ignorer la première ligne (en-têtes)
+              </label>
+              <p class="form-hint">
+                Sélectionnez pour chaque catégorie la colonne du fichier correspondante.
+              </p>
+              <div id="contact-import-mapping" class="import-mapping" aria-live="polite"></div>
+              <p id="contact-import-mapping-empty" class="empty-state" hidden>
+                Chargez un fichier Excel et assurez-vous d’avoir défini des catégories pour configurer l’import.
+              </p>
+            </div>
+            <div id="contact-import-feedback" class="import-feedback" role="status" aria-live="polite"></div>
+            <div class="form-actions import-actions">
+              <button type="button" class="primary-button" id="contact-import-submit" disabled>
+                Importer les contacts
+              </button>
+              <button type="button" class="secondary-button" id="contact-import-reset" disabled>
+                Réinitialiser
+              </button>
+            </div>
+          </form>
+          <section id="contact-import-preview" class="import-preview" hidden aria-live="polite">
+            <h2 class="import-preview-title">Aperçu des premières lignes</h2>
+            <div class="import-preview-table-wrapper">
+              <table class="import-preview-table">
+                <thead></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
         </section>
         <section id="contacts-search" class="page" aria-labelledby="contacts-search-title">
           <header class="page-header">
@@ -736,5 +795,7 @@
       </li>
     </template>
     <script src="assets/app.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="assets/importContacts.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated "Importer des contacts" section and sidebar entry in the dashboard
- expose an import API in the core app logic to map spreadsheet rows into contacts
- build a standalone module to parse Excel files, map columns to categories, preview data and trigger imports
- style the new import form, mapping grid and feedback states for clarity on any device

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc3af8e2a883269db2dd23fe78a9a2