### PR TITLE
Add pagination to contact search results

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -987,6 +987,69 @@ button {
   gap: 16px;
 }
 
+.contact-pagination {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  justify-content: space-between;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 16px 20px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.contact-pagination-info {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.contact-pagination-controls {
+  display: flex;
+  gap: 12px;
+}
+
+.contact-pagination-button {
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  background: rgba(15, 23, 42, 0.08);
+  transition: background 0.2s ease;
+}
+
+.contact-pagination-button:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.contact-pagination-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.contact-pagination-size {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.contact-pagination-size select {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-weight: 600;
+  background: #fff;
+  color: var(--color-text);
+}
+
 .contact-item {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
@@ -1342,6 +1405,26 @@ button {
 
   .contact-search-controls select {
     max-width: 100%;
+  }
+
+  .contact-pagination {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .contact-pagination-info {
+    align-items: flex-start;
+  }
+
+  .contact-pagination-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .contact-pagination-size {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -474,6 +474,43 @@
           <p id="contact-empty-state" class="empty-state" hidden>
             Ajoutez vos premiers contacts pour les retrouver ici.
           </p>
+          <nav
+            id="contact-pagination"
+            class="contact-pagination"
+            aria-label="Pagination des contacts"
+            hidden
+          >
+            <div class="contact-pagination-info">
+              <span id="contact-pagination-summary">Affichage 0 sur 0 contacts</span>
+              <span id="contact-pagination-page">Page 1 / 1</span>
+            </div>
+            <div class="contact-pagination-controls">
+              <button
+                id="contact-pagination-prev"
+                type="button"
+                class="contact-pagination-button"
+                aria-label="Page précédente"
+              >
+                Précédent
+              </button>
+              <button
+                id="contact-pagination-next"
+                type="button"
+                class="contact-pagination-button"
+                aria-label="Page suivante"
+              >
+                Suivant
+              </button>
+            </div>
+            <label class="contact-pagination-size" for="contact-results-per-page">
+              <span>Résultats par page</span>
+              <select id="contact-results-per-page" name="contact-results-per-page">
+                <option value="10" selected>10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+              </select>
+            </label>
+          </nav>
         </section>
 		<section id="tasks" class="page" aria-labelledby="tasks-title">
           <header class="page-header">


### PR DESCRIPTION
## Summary
- add pagination controls to the contact search page with default 10 results per view
- implement pagination logic, per-page selection, and navigation state handling in the dashboard script
- ensure imported contacts persist by reinitializing the stored contacts array when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc49c5f5f48326a2cc2275ae6f1c05