### PR TITLE
Add contact bulk actions and import auto merge toggle

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -948,6 +948,68 @@ button {
   max-width: 280px;
 }
 
+.contact-bulk-actions {
+  margin: 16px 0 24px;
+  padding: 16px 20px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.contact-bulk-counter {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.contact-bulk-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.contact-bulk-keyword {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.contact-bulk-keyword select {
+  min-width: 200px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.contact-bulk-keyword select:disabled {
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(71, 85, 105, 0.76);
+}
+
+.contact-bulk-delete {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.contact-bulk-delete:hover:not(:disabled) {
+  background: rgba(220, 38, 38, 0.18);
+}
+
+.contact-bulk-delete:disabled {
+  color: rgba(220, 38, 38, 0.42);
+  background: rgba(220, 38, 38, 0.1);
+}
+
 .advanced-grid {
   display: grid;
   gap: 16px;
@@ -1065,8 +1127,32 @@ button {
 .contact-header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   gap: 16px;
+}
+
+.contact-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.contact-select {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contact-select-checkbox {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.contact-select-checkbox:disabled {
+  cursor: not-allowed;
+  accent-color: rgba(148, 163, 184, 0.4);
 }
 
 .contact-name {
@@ -1380,6 +1466,10 @@ button {
     align-items: flex-start;
     gap: 6px;
   }
+
+  .contact-select {
+    align-self: flex-start;
+  }
 }
 
 @media (max-width: 600px) {
@@ -1426,6 +1516,31 @@ button {
   .contact-pagination-size {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .contact-bulk-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .contact-bulk-controls {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .contact-bulk-controls .secondary-button {
+    width: 100%;
+  }
+
+  .contact-bulk-keyword {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .contact-bulk-keyword select {
+    width: 100%;
   }
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -403,6 +403,14 @@
                 <input type="checkbox" id="contact-import-has-header" checked />
                 Ignorer la première ligne (en-têtes)
               </label>
+              <label class="import-header-toggle" for="contact-import-auto-merge">
+                <input type="checkbox" id="contact-import-auto-merge" />
+                Activer la fusion automatique des doublons détectés
+              </label>
+              <p class="form-hint import-auto-merge-hint">
+                En cas de doublon, la dernière version des données importées sera appliquée aux
+                contacts existants lorsque cette option est activée.
+              </p>
               <p class="form-hint">
                 Sélectionnez pour chaque catégorie la colonne du fichier correspondante.
               </p>
@@ -469,6 +477,37 @@
                 <button type="reset" class="secondary-button">Réinitialiser</button>
               </div>
             </form>
+          </div>
+          <div class="contact-bulk-actions">
+            <p
+              id="contact-selected-count"
+              class="contact-bulk-counter"
+              aria-live="polite"
+            >
+              Aucun contact sélectionné
+            </p>
+            <div class="contact-bulk-controls">
+              <button type="button" class="secondary-button" id="contact-select-all" disabled>
+                Sélectionner tous les résultats
+              </button>
+              <button
+                type="button"
+                class="secondary-button contact-bulk-delete"
+                id="contact-delete-selected"
+                disabled
+              >
+                Supprimer la sélection
+              </button>
+              <div class="contact-bulk-keyword">
+                <label for="contact-bulk-keyword" class="sr-only">Mot clé à ajouter</label>
+                <select id="contact-bulk-keyword" disabled>
+                  <option value="">Choisir un mot clé</option>
+                </select>
+                <button type="button" class="secondary-button" id="contact-add-keyword" disabled>
+                  Ajouter le mot clé
+                </button>
+              </div>
+            </div>
           </div>
           <ul id="contact-list" class="contact-list" aria-live="polite"></ul>
           <p id="contact-empty-state" class="empty-state" hidden>
@@ -769,8 +808,14 @@
     <template id="contact-item-template">
       <li class="contact-item">
         <div class="contact-header">
-          <h3 class="contact-name"></h3>
-          <span class="contact-created"></span>
+          <div class="contact-header-text">
+            <h3 class="contact-name"></h3>
+            <span class="contact-created"></span>
+          </div>
+          <label class="contact-select">
+            <input type="checkbox" class="contact-select-checkbox" />
+            <span class="sr-only">Sélectionner ce contact</span>
+          </label>
         </div>
         <div class="contact-details">
           <p class="contact-coordinates"></p>


### PR DESCRIPTION
## Summary
- add an optional auto-merge control to the import workflow and ensure backend logic honours the latest imported version while tracking detected duplicates
- surface duplicate counts in import feedback and disable automatic merging when the toggle is off
- introduce bulk contact selection controls to the search page, supporting select-all, bulk deletion and keyword assignment with updated styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc7a9e7c9483268d30c242d3846264