### PR TITLE
feat: finalize task categories and attachments

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -305,6 +305,220 @@ button {
   gap: 24px;
 }
 
+.task-category-manager {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.08));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  border-radius: var(--radius-md);
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.task-category-manager-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.task-category-manager-subtitle {
+  margin: 6px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.task-category-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.task-category-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+  align-items: end;
+}
+
+.task-category-form-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.task-category-submit {
+  background: rgba(37, 99, 235, 0.95);
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.task-category-submit:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.task-category-reset {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(255, 255, 255, 0.7);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.task-category-reset:hover {
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--color-primary);
+  transform: rotate(-8deg);
+}
+
+.task-category-nav-wrapper {
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.task-category-nav {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.task-category-nav::-webkit-scrollbar {
+  height: 6px;
+}
+
+.task-category-nav::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.15);
+  border-radius: 999px;
+}
+
+.task-category-indicator {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  height: calc(100% - 8px);
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  transition: transform 0.25s ease, width 0.25s ease, opacity 0.2s ease;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.task-category-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: transparent;
+  color: var(--color-text-secondary);
+  transition: color 0.2s ease;
+  white-space: nowrap;
+}
+
+.task-category-chip:hover {
+  color: var(--color-text);
+}
+
+.task-category-chip.active {
+  color: var(--color-primary);
+}
+
+.task-category-chip-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.task-category-chip-count {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.task-category-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.task-category-empty {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--color-text-secondary);
+}
+
+.task-category-item {
+  --task-category-color: var(--color-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.task-category-item-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.task-category-item-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--task-category-color);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.task-category-item-count {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.task-category-item-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.task-category-item-delete {
+  background: transparent;
+  color: var(--color-danger);
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.task-category-item-delete:hover {
+  background: rgba(220, 38, 38, 0.1);
+  color: #b91c1c;
+}
+
 .task-panel-header {
   display: flex;
   align-items: flex-start;
@@ -332,6 +546,102 @@ button {
   display: flex;
   flex-direction: column;
   gap: 18px;
+}
+
+.task-attachment-field {
+  gap: 10px;
+}
+
+.task-attachment-preview {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.task-attachment-preview-icon {
+  font-size: 1.2rem;
+}
+
+.task-attachment-preview-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.task-attachment-preview-name {
+  font-weight: 600;
+}
+
+.task-attachment-preview-meta {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.task-attachment-preview-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+.task-attachment-preview-action {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.task-attachment-preview-action:hover {
+  text-decoration: underline;
+}
+
+.task-attachment-preview-remove {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--color-danger);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.task-attachment-preview-remove:hover {
+  background: rgba(220, 38, 38, 0.18);
+  color: #b91c1c;
+}
+
+.task-attachment-removed-message {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.task-attachment {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.task-attachment-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.task-attachment-link:hover {
+  text-decoration: underline;
+}
+
+.task-attachment-link-icon {
+  font-size: 1rem;
+}
+
+.task-attachment-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
 }
 
 .task-form-grid {
@@ -386,6 +696,28 @@ button {
   box-shadow: var(--shadow-card);
 }
 
+.task-item--assigned-me {
+  animation: task-assigned-me 2.4s ease-in-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task-item--assigned-me {
+    animation: none;
+  }
+}
+
+@keyframes task-assigned-me {
+  0% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 14px rgba(37, 99, 235, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+  }
+}
+
 .task-item-header {
   display: flex;
   align-items: flex-start;
@@ -406,6 +738,21 @@ button {
   align-items: flex-end;
   gap: 8px;
   min-width: 180px;
+}
+
+.task-item-category {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.task-item-category--default {
+  color: var(--color-text-secondary);
+  background: rgba(15, 23, 42, 0.1);
 }
 
 .task-due-date {

--- a/dashboard.html
+++ b/dashboard.html
@@ -570,6 +570,67 @@
               </div>
             </header>
 
+            <section
+              class="task-category-manager"
+              aria-labelledby="task-category-manager-title"
+            >
+              <header class="task-category-manager-header">
+                <div>
+                  <h2 id="task-category-manager-title">Organiser par catégories</h2>
+                  <p class="task-category-manager-subtitle">
+                    Créez des catégories personnalisées pour classer vos tâches et
+                    naviguez facilement entre elles.
+                  </p>
+                </div>
+              </header>
+              <form id="task-category-form" class="task-category-form" autocomplete="off">
+                <div class="task-category-form-grid">
+                  <div class="form-row">
+                    <label for="task-category-name">Nom de la catégorie *</label>
+                    <input
+                      id="task-category-name"
+                      name="task-category-name"
+                      type="text"
+                      maxlength="40"
+                      required
+                      placeholder="Ex. Urgent, Partenaires, Communication"
+                    />
+                  </div>
+                  <div class="form-row">
+                    <label for="task-category-color">Couleur</label>
+                    <input
+                      id="task-category-color"
+                      name="task-category-color"
+                      type="color"
+                      value="#4f46e5"
+                    />
+                  </div>
+                  <div class="task-category-form-actions">
+                    <button type="submit" class="task-category-submit">Créer la catégorie</button>
+                    <button type="reset" class="task-category-reset" aria-label="Réinitialiser le formulaire des catégories">↺</button>
+                  </div>
+                </div>
+              </form>
+              <div class="task-category-nav-wrapper">
+                <div
+                  id="task-category-nav"
+                  class="task-category-nav"
+                  role="tablist"
+                  aria-label="Filtrer les tâches par catégorie"
+                >
+                  <span
+                    id="task-category-indicator"
+                    class="task-category-indicator"
+                    aria-hidden="true"
+                  ></span>
+                </div>
+              </div>
+              <ul id="task-category-list" class="task-category-list" aria-live="polite"></ul>
+              <p id="task-category-empty" class="task-category-empty">
+                Aucune catégorie de tâche pour le moment. Utilisez le formulaire ci-dessus pour en ajouter.
+              </p>
+            </section>
+
             <form id="task-form" class="task-form" autocomplete="off">
               <div class="task-form-grid">
                 <div class="form-row">
@@ -586,6 +647,12 @@
                 <div class="form-row">
                   <label for="task-due-date">Date limite</label>
                   <input id="task-due-date" name="task-due-date" type="date" />
+                </div>
+                <div class="form-row">
+                  <label for="task-category">Catégorie</label>
+                  <select id="task-category" name="task-category">
+                    <option value="">Sans catégorie</option>
+                  </select>
                 </div>
                 <div class="form-row">
                   <label for="task-color">Couleur</label>
@@ -614,6 +681,46 @@
                   maxlength="500"
                   placeholder="Précisez les objectifs ou les étapes à suivre (optionnel)."
                 ></textarea>
+              </div>
+              <div class="form-row task-attachment-field">
+                <label for="task-attachment">Document associé</label>
+                <input
+                  id="task-attachment"
+                  name="task-attachment"
+                  type="file"
+                  accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.txt,.zip"
+                />
+                <p class="form-hint">
+                  Formats courants acceptés (PDF, Word, tableurs, images). Taille maximale 2&nbsp;Mo.
+                </p>
+                <div id="task-attachment-preview" class="task-attachment-preview" hidden>
+                  <div class="task-attachment-preview-icon" aria-hidden="true">📎</div>
+                  <div class="task-attachment-preview-info">
+                    <span id="task-attachment-preview-name" class="task-attachment-preview-name"></span>
+                    <span id="task-attachment-preview-meta" class="task-attachment-preview-meta"></span>
+                  </div>
+                  <div class="task-attachment-preview-actions">
+                    <a
+                      id="task-attachment-preview-open"
+                      class="task-attachment-preview-action"
+                      href="#"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      Ouvrir
+                    </a>
+                    <button
+                      id="task-attachment-remove"
+                      type="button"
+                      class="task-attachment-preview-remove"
+                    >
+                      Retirer
+                    </button>
+                  </div>
+                </div>
+                <p id="task-attachment-removed-message" class="task-attachment-removed-message" hidden>
+                  Le document existant sera supprimé lors de l’enregistrement.
+                </p>
               </div>
               <div class="task-form-actions">
                 <button type="submit" class="primary-button">Ajouter la tâche</button>


### PR DESCRIPTION
## Summary
- add a task category manager with filtering chips and an attachment field to the task form
- style the new category navigation, attachment preview, and highlight for tasks assigned to the active user
- update dashboard logic to manage task categories, persist attachments, and animate assignments for the current member

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cdcddb878483268df2041acc1f7131