### PR TITLE
Séparer création/recherche des tâches et types de contacts

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -807,6 +807,10 @@ button {
   gap: 12px;
 }
 
+.task-list-actions {
+  margin-bottom: 16px;
+}
+
 .task-list-controls {
   display: flex;
   flex-wrap: wrap;
@@ -889,6 +893,8 @@ button {
 }
 
 .task-item--assigned-me {
+  --task-color: #dc2626;
+  --task-color-soft: rgba(220, 38, 38, 0.12);
   animation: task-assigned-me 2.4s ease-in-out 2;
 }
 
@@ -900,13 +906,13 @@ button {
 
 @keyframes task-assigned-me {
   0% {
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.35);
+    box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.35);
   }
   50% {
-    box-shadow: 0 0 0 14px rgba(37, 99, 235, 0);
+    box-shadow: 0 0 0 14px rgba(220, 38, 38, 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+    box-shadow: 0 0 0 0 rgba(220, 38, 38, 0);
   }
 }
 
@@ -1709,6 +1715,13 @@ button {
   gap: 4px;
 }
 
+.contact-header-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .contact-select {
   display: inline-flex;
   align-items: center;
@@ -1730,6 +1743,37 @@ button {
 .contact-name {
   margin: 0;
   font-size: 1.2rem;
+}
+
+.contact-type-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.contact-type-badge--person {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.contact-type-badge--company {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.contact-type-badge--association {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.contact-type-badge--institution {
+  background: #ede9fe;
+  color: #6d28d9;
 }
 
 .contact-created {

--- a/dashboard.html
+++ b/dashboard.html
@@ -62,7 +62,7 @@
             </div>
             <div class="task-summary-actions">
               <button class="primary-button" type="button" data-navigate="tasks-list">
-                Consulter la liste des tâches
+                Accéder à la recherche de tâches
               </button>
             </div>
           </section>
@@ -127,49 +127,15 @@
             </section>
           </section>
 
-          <section id="tasks-list" class="page" aria-labelledby="tasks-list-title">
+          <section id="tasks-create" class="page" aria-labelledby="tasks-create-title">
             <header class="page-header">
               <div>
-                <h1 id="tasks-list-title">Liste de tâches</h1>
+                <h1 id="tasks-create-title">Créer une tâche</h1>
                 <p id="task-panel-description" class="page-subtitle">
                   Centralisez vos actions et attribuez-les aux membres de l'équipe.
                 </p>
               </div>
-              <span id="task-count-badge" class="task-count-badge" aria-live="polite">0 tâche</span>
             </header>
-
-            <div class="task-list-controls">
-              <div class="task-status-filter" role="group" aria-label="Filtrer les tâches par statut">
-                <button
-                  type="button"
-                  class="task-status-button active"
-                  data-task-status="active"
-                  aria-pressed="true"
-                >
-                  En cours
-                  <span class="task-status-count" data-task-status-count="active">0</span>
-                </button>
-                <button
-                  type="button"
-                  class="task-status-button"
-                  data-task-status="archived"
-                  aria-pressed="false"
-                >
-                  Archivées
-                  <span class="task-status-count" data-task-status-count="archived">0</span>
-                </button>
-              </div>
-              <div class="task-category-nav-wrapper">
-                <div
-                  id="task-category-nav"
-                  class="task-category-nav"
-                  role="tablist"
-                  aria-label="Filtrer les tâches par catégorie"
-                >
-                  <span id="task-category-indicator" class="task-category-indicator" aria-hidden="true"></span>
-                </div>
-              </div>
-            </div>
 
             <form id="task-form" class="task-form" autocomplete="off">
               <div class="task-form-grid">
@@ -263,10 +229,61 @@
                 <button type="reset" class="secondary-button">Réinitialiser</button>
               </div>
             </form>
+          </section>
+
+          <section id="tasks-list" class="page" aria-labelledby="tasks-list-title">
+            <header class="page-header">
+              <div>
+                <h1 id="tasks-list-title">Recherche de tâches</h1>
+                <p class="page-subtitle">
+                  Consultez vos actions en cours et affinez votre recherche par statut ou catégorie.
+                </p>
+              </div>
+              <span id="task-count-badge" class="task-count-badge" aria-live="polite">0 tâche</span>
+            </header>
+
+            <div class="task-list-actions">
+              <button class="secondary-button" type="button" data-navigate="tasks-create">
+                Créer une nouvelle tâche
+              </button>
+            </div>
+
+            <div class="task-list-controls">
+              <div class="task-status-filter" role="group" aria-label="Filtrer les tâches par statut">
+                <button
+                  type="button"
+                  class="task-status-button active"
+                  data-task-status="active"
+                  aria-pressed="true"
+                >
+                  En cours
+                  <span class="task-status-count" data-task-status-count="active">0</span>
+                </button>
+                <button
+                  type="button"
+                  class="task-status-button"
+                  data-task-status="archived"
+                  aria-pressed="false"
+                >
+                  Archivées
+                  <span class="task-status-count" data-task-status-count="archived">0</span>
+                </button>
+              </div>
+              <div class="task-category-nav-wrapper">
+                <div
+                  id="task-category-nav"
+                  class="task-category-nav"
+                  role="tablist"
+                  aria-label="Filtrer les tâches par catégorie"
+                >
+                  <span id="task-category-indicator" class="task-category-indicator" aria-hidden="true"></span>
+                </div>
+              </div>
+            </div>
             <div class="task-list-wrapper">
               <ul id="task-list" class="task-list" aria-live="polite"></ul>
               <p id="task-empty-state" class="task-empty-state">
-                Aucune tâche planifiée pour le moment. Ajoutez votre première action ci-dessus.
+                Aucune tâche planifiée pour le moment. Ajoutez votre première action depuis l’onglet «&nbsp;Créer une tâche&nbsp;».
               </p>
             </div>
           </section>
@@ -395,6 +412,15 @@
               </div>
             </header>
             <form id="contact-form" class="contact-form" autocomplete="off">
+              <div class="form-row">
+                <label for="contact-type">Type de contact</label>
+                <select id="contact-type" name="contact-type">
+                  <option value="person" selected>Personne</option>
+                  <option value="company">Entreprise</option>
+                  <option value="association">Association</option>
+                  <option value="institution">Institution</option>
+                </select>
+              </div>
               <fieldset id="contact-categories-fieldset" class="form-fieldset">
                 <legend>Données personnalisées</legend>
                 <p class="form-hint">
@@ -787,7 +813,10 @@
       <li class="contact-item">
         <div class="contact-header">
           <div class="contact-header-text">
-            <h3 class="contact-name"></h3>
+            <div class="contact-header-main">
+              <h3 class="contact-name"></h3>
+              <span class="contact-type-badge"></span>
+            </div>
             <span class="contact-created"></span>
           </div>
           <label class="contact-select">


### PR DESCRIPTION
## Résumé
- ajouter une page dédiée à la création de tâches et adapter la navigation ainsi que le panneau de recherche
- permettre de choisir un type de contact lors de la saisie et afficher un badge coloré dans les résultats
- mettre en évidence en rouge les tâches attribuées à l’utilisateur tout en conservant le bleu pour les autres

## Tests
- non exécutés (non disponibles)


------
https://chatgpt.com/codex/tasks/task_e_68ce6c5ef4a0832688b1633d95cda27f