### PR TITLE
Add team chat feature and improve task workflows

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -872,6 +872,78 @@ button {
   font-style: italic;
 }
 
+.team-chat-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-card);
+}
+
+.team-chat-messages-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-chat-messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 340px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-chat-message {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.team-chat-message-meta {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.team-chat-message-content {
+  margin: 0;
+  color: var(--color-text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.team-chat-empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.team-chat-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-chat-form textarea {
+  resize: vertical;
+}
+
+.team-chat-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .task-item {
   --task-color: var(--color-primary);
   --task-color-soft: rgba(37, 99, 235, 0.08);
@@ -2566,7 +2638,7 @@ button {
 
 .import-mapping {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -2706,6 +2778,12 @@ button {
   border-bottom: none;
 }
 
+@media (max-width: 1200px) {
+  .import-mapping {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 1024px) {
   .calendar-side {
     width: 280px;
@@ -2727,6 +2805,10 @@ button {
     border-top: 1px solid var(--color-border);
     padding: 20px 24px;
     max-height: none;
+  }
+
+  .import-mapping {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -288,6 +288,47 @@
             </div>
           </section>
 
+          <section id="team-chat" class="page" aria-labelledby="team-chat-title">
+            <header class="page-header">
+              <div>
+                <h1 id="team-chat-title">Tchat interne</h1>
+                <p class="page-subtitle">
+                  Échangez en direct avec les membres de l'équipe pour coordonner vos actions.
+                </p>
+              </div>
+            </header>
+
+            <div class="team-chat-panel">
+              <div class="team-chat-messages-wrapper">
+                <ul
+                  id="team-chat-messages"
+                  class="team-chat-messages"
+                  aria-live="polite"
+                  role="list"
+                ></ul>
+                <p id="team-chat-empty" class="team-chat-empty">
+                  Aucun message pour le moment. Démarrez la conversation avec votre équipe.
+                </p>
+              </div>
+              <form id="team-chat-form" class="team-chat-form" autocomplete="off">
+                <div class="form-row">
+                  <label class="sr-only" for="team-chat-input">Votre message</label>
+                  <textarea
+                    id="team-chat-input"
+                    name="team-chat-input"
+                    rows="3"
+                    maxlength="500"
+                    placeholder="Écrivez un message à votre équipe..."
+                    required
+                  ></textarea>
+                </div>
+                <div class="team-chat-actions">
+                  <button type="submit" class="primary-button">Envoyer</button>
+                </div>
+              </form>
+            </div>
+          </section>
+
           <section id="categories" class="page" aria-labelledby="categories-title">
             <header class="page-header">
               <div>


### PR DESCRIPTION
## Summary
- add an internal chat page to the tasks module with persisted messages and UI updates
- improve task editing by redirecting to the creation page and offering a "Personne" option when assigning members
- update the contact import mapping layout to display five columns per row with responsive fallbacks

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce71e3c76483269cc48ebc19e73937