### PR TITLE
Convert task management to Kanban board

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -858,12 +858,97 @@ button {
 }
 
 .task-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  --task-board-scroll-shadow: rgba(15, 23, 42, 0.08);
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  overflow-x: auto;
+  padding: 4px 4px 12px;
+  margin: 0 -4px;
+}
+
+.task-list::before,
+.task-list::after {
+  content: '';
+  flex: 0 0 4px;
+}
+
+.task-list::-webkit-scrollbar {
+  height: 10px;
+}
+
+.task-list::-webkit-scrollbar-track {
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+}
+
+.task-list::-webkit-scrollbar-thumb {
+  background: var(--task-board-scroll-shadow);
+  border-radius: 999px;
+}
+
+.task-board-column {
+  --task-board-color: var(--color-primary);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  min-width: 280px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding: 20px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+.task-board-column--focused {
+  border-color: var(--task-board-color);
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.18);
+}
+
+.task-board-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.task-board-column-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.task-board-column-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--task-board-color);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.08);
+}
+
+.task-board-column-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.task-board-column-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.task-board-column-empty {
+  margin: 0;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--color-text-secondary);
+  font-style: italic;
 }
 
 .task-empty-state {
@@ -956,6 +1041,7 @@ button {
   gap: 14px;
   background: var(--task-color-soft);
   box-shadow: var(--shadow-card);
+  width: 100%;
 }
 
 .task-item--archived {

--- a/dashboard.html
+++ b/dashboard.html
@@ -234,9 +234,9 @@
           <section id="tasks-list" class="page" aria-labelledby="tasks-list-title">
             <header class="page-header">
               <div>
-                <h1 id="tasks-list-title">Recherche de tâches</h1>
+                <h1 id="tasks-list-title">Tableau Kanban des tâches</h1>
                 <p class="page-subtitle">
-                  Consultez vos actions en cours et affinez votre recherche par statut ou catégorie.
+                  Visualisez vos actions par catégorie dans un tableau Kanban et suivez leur avancement en un coup d’œil.
                 </p>
               </div>
               <span id="task-count-badge" class="task-count-badge" aria-live="polite">0 tâche</span>
@@ -281,9 +281,9 @@
               </div>
             </div>
             <div class="task-list-wrapper">
-              <ul id="task-list" class="task-list" aria-live="polite"></ul>
+              <div id="task-list" class="task-list" aria-live="polite"></div>
               <p id="task-empty-state" class="task-empty-state">
-                Aucune tâche planifiée pour le moment. Ajoutez votre première action depuis l’onglet «&nbsp;Créer une tâche&nbsp;».
+                Aucune carte n’est disponible pour le moment. Ajoutez votre première tâche depuis l’onglet «&nbsp;Créer une tâche&nbsp;».
               </p>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- refactor task rendering logic to build Kanban columns populated per category
- style the task view as a horizontal Kanban board with column states and empty placeholders
- update dashboard copy and markup to reflect the new Kanban experience

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce89e881d08326aac72e446bf7ccde