### PR TITLE
feat: finaliser l’outil de communication

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -22,6 +22,9 @@
     taskCategories: [],
     tasks: [],
     teamChatMessages: [],
+    savedSearches: [],
+    emailTemplates: [],
+    emailCampaigns: [],
     lastUpdated: null,
   };
 
@@ -373,13 +376,18 @@
       ],
       directory: [
         { id: 'categories', label: 'Catégorie' },
-        { id: 'keywords', label: 'Mots clés' },
-        { id: 'contacts-add', label: 'Ajouter des contacts' },
-        { id: 'contacts-import', label: 'Importer des contacts' },
-        { id: 'contacts-search', label: 'Rechercher des contacts' },
-      ],
-      team: [{ id: 'team', label: "Gestion de l'équipe" }],
-    };
+    { id: 'keywords', label: 'Mots clés' },
+    { id: 'contacts-add', label: 'Ajouter des contacts' },
+    { id: 'contacts-import', label: 'Importer des contacts' },
+    { id: 'contacts-search', label: 'Rechercher des contacts' },
+    { id: 'saved-searches', label: 'Recherches sauvegardées' },
+  ],
+  communication: [
+    { id: 'email-templates', label: 'Créer un modèle mail' },
+    { id: 'email-campaigns', label: 'Envoyer une campagne de mail' },
+  ],
+  team: [{ id: 'team', label: "Gestion de l'équipe" }],
+};
 
     const pageModuleMap = new Map();
     Object.entries(MODULE_CONFIG).forEach(([moduleId, entries]) => {
@@ -410,6 +418,7 @@
     const keywordsCountEl = document.getElementById('keywords-count');
     const categoriesActiveCountEl = document.getElementById('categories-active-count');
     const keywordsActiveCountEl = document.getElementById('keywords-active-count');
+    const savedSearchCountEl = document.getElementById('saved-search-count');
     const lastUpdatedEl = document.getElementById('last-updated');
     const categoryForm = document.getElementById('category-form');
     const categoryList = document.getElementById('category-list');
@@ -437,6 +446,11 @@
     const searchCategoriesEmpty = document.getElementById('search-categories-empty');
     const searchKeywordsSelect = document.getElementById('search-keywords');
     const contactSearchCountEl = document.getElementById('contact-search-count');
+    const contactSaveSearchButton = document.getElementById('contact-save-search');
+    const contactSavedSearchSelect = document.getElementById('contact-saved-searches');
+    const contactSaveSearchFeedback = document.getElementById('contact-save-search-feedback');
+    const savedSearchList = document.getElementById('saved-search-list');
+    const savedSearchEmptyState = document.getElementById('saved-search-empty');
     const contactSelectAllButton = document.getElementById('contact-select-all');
     const contactDeleteSelectedButton = document.getElementById('contact-delete-selected');
     const contactBulkKeywordSelect = document.getElementById('contact-bulk-keyword');
@@ -503,6 +517,30 @@
     const teamChatEmptyState = document.getElementById('team-chat-empty');
     const teamChatForm = document.getElementById('team-chat-form');
     const teamChatInput = document.getElementById('team-chat-input');
+    const emailTemplateForm = document.getElementById('email-template-form');
+    const emailTemplateNameInput = document.getElementById('email-template-name');
+    const emailTemplateSubjectInput = document.getElementById('email-template-subject');
+    const emailTemplateBlocksContainer = document.getElementById('email-template-blocks');
+    const emailTemplateAddParagraphButton = document.getElementById('email-template-add-paragraph');
+    const emailTemplateAddImageButton = document.getElementById('email-template-add-image');
+    const emailTemplateAddButtonBlockButton = document.getElementById('email-template-add-button');
+    const emailTemplatePreview = document.getElementById('email-template-preview');
+    const emailTemplateFeedback = document.getElementById('email-template-feedback');
+    const emailTemplateList = document.getElementById('email-template-list');
+    const emailTemplateEmptyState = document.getElementById('email-template-empty');
+    const emailCampaignForm = document.getElementById('email-campaign-form');
+    const emailCampaignNameInput = document.getElementById('email-campaign-name');
+    const emailCampaignSenderNameInput = document.getElementById('email-campaign-sender-name');
+    const emailCampaignSenderEmailInput = document.getElementById('email-campaign-sender-email');
+    const emailCampaignTemplateSelect = document.getElementById('campaign-template-select');
+    const emailCampaignSavedSearchSelect = document.getElementById('campaign-saved-search-select');
+    const emailCampaignSubjectInput = document.getElementById('email-campaign-subject');
+    const emailCampaignFeedback = document.getElementById('email-campaign-feedback');
+    const campaignSummaryEl = document.getElementById('campaign-summary');
+    const campaignRecipientList = document.getElementById('campaign-recipient-list');
+    const campaignEmailPreview = document.getElementById('campaign-email-preview');
+    const campaignHistoryList = document.getElementById('campaign-history-list');
+    const campaignHistoryEmptyState = document.getElementById('campaign-history-empty');
 
     const CATEGORY_TYPE_ORDER = ['text', 'number', 'date', 'list'];
     const CATEGORY_TYPES = new Set(CATEGORY_TYPE_ORDER);
@@ -555,6 +593,14 @@
       dateStyle: 'medium',
     });
     const taskCommentDateFormatter = new Intl.DateTimeFormat('fr-FR', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+    const savedSearchDateFormatter = new Intl.DateTimeFormat('fr-FR', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+    const emailCampaignDateFormatter = new Intl.DateTimeFormat('fr-FR', {
       dateStyle: 'medium',
       timeStyle: 'short',
     });
@@ -612,6 +658,12 @@
 
     let contactSearchTerm = '';
     let advancedFilters = createEmptyAdvancedFilters();
+    let lastAppliedSavedSearchId = '';
+    let editingEmailTemplateId = '';
+    let emailTemplateBlocks = [];
+    let campaignSubjectManuallyEdited = false;
+    let isResettingEmailTemplateForm = false;
+    let isResettingEmailCampaignForm = false;
     let contactEditReturnPage = 'contacts-search';
     let contactCurrentPage = 1;
     let contactResultsPerPage = CONTACT_RESULTS_PER_PAGE_DEFAULT;
@@ -1379,6 +1431,575 @@
         });
       });
     }
+
+    if (contactSaveSearchButton instanceof HTMLButtonElement) {
+      contactSaveSearchButton.addEventListener('click', () => {
+        const trimmedTerm = (contactSearchTerm || '').toString().trim();
+        const filtersForSave = cloneAdvancedFiltersForStorage(advancedFilters);
+        if (!trimmedTerm && !hasActiveAdvancedFilters(filtersForSave)) {
+          setContactSaveSearchFeedback(
+            'Définissez au moins un critère de recherche avant de l’enregistrer.',
+            'error',
+          );
+          return;
+        }
+
+        const lastApplied = lastAppliedSavedSearchId ? getSavedSearchById(lastAppliedSavedSearchId) : null;
+        const proposedName = lastApplied ? lastApplied.name : '';
+        const promptValue = window.prompt('Nom de la recherche sauvegardée', proposedName || '');
+        const normalizedName = promptValue ? promptValue.toString().trim() : '';
+        if (!normalizedName) {
+          setContactSaveSearchFeedback('Enregistrement annulé.', 'info');
+          return;
+        }
+
+        if (!Array.isArray(data.savedSearches)) {
+          data.savedSearches = [];
+        }
+
+        const nowIso = new Date().toISOString();
+        const lowerName = normalizedName.toLowerCase();
+        const existingIndex = data.savedSearches.findIndex((search) =>
+          search && typeof search.name === 'string' && search.name.toLowerCase() === lowerName,
+        );
+
+        const baseSavedSearch =
+          existingIndex >= 0 && data.savedSearches[existingIndex]
+            ? { ...data.savedSearches[existingIndex] }
+            : { id: generateId('saved-search'), createdAt: nowIso };
+
+        const normalizedSavedSearch = normalizeSavedSearch({
+          ...baseSavedSearch,
+          name: normalizedName,
+          searchTerm: trimmedTerm,
+          filters: filtersForSave,
+          createdAt: baseSavedSearch.createdAt || nowIso,
+          updatedAt: nowIso,
+        });
+
+        if (existingIndex >= 0) {
+          data.savedSearches.splice(existingIndex, 1, normalizedSavedSearch);
+        } else {
+          data.savedSearches.push(normalizedSavedSearch);
+        }
+
+        lastAppliedSavedSearchId = normalizedSavedSearch.id;
+        data.lastUpdated = nowIso;
+        saveDataForUser(currentUser, data);
+        renderSavedSearchSelect(normalizedSavedSearch.id);
+        renderSavedSearchList();
+        renderCampaignSavedSearchOptions(normalizedSavedSearch.id);
+        setContactSaveSearchFeedback(`Recherche "${normalizedSavedSearch.name}" sauvegardée.`, 'success');
+      });
+    }
+
+    if (contactSavedSearchSelect instanceof HTMLSelectElement) {
+      contactSavedSearchSelect.addEventListener('change', () => {
+        const selectedId = contactSavedSearchSelect.value || '';
+        if (!selectedId) {
+          lastAppliedSavedSearchId = '';
+          setContactSaveSearchFeedback('', 'info');
+          return;
+        }
+        applySavedSearchById(selectedId, { showFeedback: true, updateSelect: false });
+      });
+    }
+
+    if (savedSearchList) {
+      savedSearchList.addEventListener('click', (event) => {
+        const button =
+          event.target instanceof HTMLElement
+            ? event.target.closest('button[data-saved-search-action]')
+            : null;
+        if (!(button instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        const action = button.dataset.savedSearchAction || '';
+        const savedSearchId = button.dataset.savedSearchId || '';
+        if (!savedSearchId) {
+          return;
+        }
+
+        if (action === 'apply') {
+          const applied = applySavedSearchById(savedSearchId, { showFeedback: true });
+          if (applied) {
+            activateModule('directory', 'contacts-search');
+          }
+          return;
+        }
+
+        const savedSearch = getSavedSearchById(savedSearchId);
+        if (!savedSearch) {
+          renderSavedSearchList();
+          return;
+        }
+
+        if (action === 'rename') {
+          const input = window.prompt('Nouveau nom de la recherche', savedSearch.name || '');
+          const newName = input ? input.toString().trim() : '';
+          if (!newName) {
+            return;
+          }
+          const nowIso = new Date().toISOString();
+          const updatedSavedSearch = normalizeSavedSearch({
+            ...savedSearch,
+            name: newName,
+            updatedAt: nowIso,
+          });
+          data.savedSearches = data.savedSearches.map((item) =>
+            item && item.id === savedSearchId ? updatedSavedSearch : item,
+          );
+          data.lastUpdated = nowIso;
+          saveDataForUser(currentUser, data);
+          renderSavedSearchSelect(savedSearchId);
+          renderSavedSearchList();
+          renderCampaignSavedSearchOptions(savedSearchId);
+          setContactSaveSearchFeedback(`Recherche renommée en "${newName}".`, 'success');
+          return;
+        }
+
+        if (action === 'delete') {
+          if (!window.confirm(`Supprimer la recherche "${savedSearch.name}" ?`)) {
+            return;
+          }
+          data.savedSearches = data.savedSearches.filter((item) => item && item.id !== savedSearchId);
+          data.lastUpdated = new Date().toISOString();
+          saveDataForUser(currentUser, data);
+          if (lastAppliedSavedSearchId === savedSearchId) {
+            lastAppliedSavedSearchId = '';
+          }
+          renderSavedSearchSelect(lastAppliedSavedSearchId);
+          renderSavedSearchList();
+          renderCampaignSavedSearchOptions('');
+          setContactSaveSearchFeedback('Recherche supprimée.', 'success');
+        }
+      });
+    }
+
+    if (emailTemplateAddParagraphButton instanceof HTMLButtonElement) {
+      emailTemplateAddParagraphButton.addEventListener('click', () => {
+        emailTemplateBlocks.push(createTemplateBlock('paragraph'));
+        renderEmailTemplateBlocks();
+        renderEmailTemplatePreview();
+        if (emailTemplateFeedback) {
+          emailTemplateFeedback.textContent = '';
+          emailTemplateFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+        }
+      });
+    }
+
+    if (emailTemplateAddImageButton instanceof HTMLButtonElement) {
+      emailTemplateAddImageButton.addEventListener('click', () => {
+        emailTemplateBlocks.push(createTemplateBlock('image'));
+        renderEmailTemplateBlocks();
+        renderEmailTemplatePreview();
+        if (emailTemplateFeedback) {
+          emailTemplateFeedback.textContent = '';
+          emailTemplateFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+        }
+      });
+    }
+
+    if (emailTemplateAddButtonBlockButton instanceof HTMLButtonElement) {
+      emailTemplateAddButtonBlockButton.addEventListener('click', () => {
+        emailTemplateBlocks.push(createTemplateBlock('button'));
+        renderEmailTemplateBlocks();
+        renderEmailTemplatePreview();
+        if (emailTemplateFeedback) {
+          emailTemplateFeedback.textContent = '';
+          emailTemplateFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+        }
+      });
+    }
+
+    if (emailTemplateBlocksContainer) {
+      emailTemplateBlocksContainer.addEventListener('input', (event) => {
+        const target = event.target;
+        if (
+          !target ||
+          !(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)
+        ) {
+          return;
+        }
+
+        const blockId = target.dataset.blockId || '';
+        const field = target.dataset.blockField || '';
+        if (!blockId || !field) {
+          return;
+        }
+
+        const index = emailTemplateBlocks.findIndex((block) => block && block.id === blockId);
+        if (index < 0) {
+          return;
+        }
+
+        const updatedBlock = { ...emailTemplateBlocks[index], [field]: target.value };
+        emailTemplateBlocks.splice(index, 1, updatedBlock);
+        renderEmailTemplatePreview();
+      });
+
+      emailTemplateBlocksContainer.addEventListener('click', (event) => {
+        const button =
+          event.target instanceof HTMLElement
+            ? event.target.closest('button[data-block-action]')
+            : null;
+        if (!(button instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        const blockId = button.dataset.blockId || '';
+        const action = button.dataset.blockAction || '';
+        if (!blockId || !action) {
+          return;
+        }
+
+        const index = emailTemplateBlocks.findIndex((block) => block && block.id === blockId);
+        if (index < 0) {
+          return;
+        }
+
+        if (action === 'move-up' && index > 0) {
+          const temp = emailTemplateBlocks[index - 1];
+          emailTemplateBlocks[index - 1] = emailTemplateBlocks[index];
+          emailTemplateBlocks[index] = temp;
+        } else if (action === 'move-down' && index < emailTemplateBlocks.length - 1) {
+          const temp = emailTemplateBlocks[index + 1];
+          emailTemplateBlocks[index + 1] = emailTemplateBlocks[index];
+          emailTemplateBlocks[index] = temp;
+        } else if (action === 'delete') {
+          emailTemplateBlocks.splice(index, 1);
+        } else {
+          return;
+        }
+
+        renderEmailTemplateBlocks();
+        renderEmailTemplatePreview();
+      });
+    }
+
+    if (emailTemplateForm) {
+      emailTemplateForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+
+        if (!(emailTemplateNameInput instanceof HTMLInputElement)) {
+          return;
+        }
+        if (!(emailTemplateSubjectInput instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const name = emailTemplateNameInput.value.trim();
+        const subject = emailTemplateSubjectInput.value.trim();
+        const normalizedBlocks = Array.isArray(emailTemplateBlocks)
+          ? emailTemplateBlocks
+              .map((block) => normalizeEmailTemplateBlock(block))
+              .filter((block) => Boolean(block))
+          : [];
+
+        if (normalizedBlocks.length === 0) {
+          if (emailTemplateFeedback) {
+            emailTemplateFeedback.textContent =
+              'Ajoutez au moins un bloc valide (paragraphe, image ou bouton) avant de sauvegarder.';
+            emailTemplateFeedback.classList.add('form-feedback--error');
+            emailTemplateFeedback.classList.remove('form-feedback--success');
+          }
+          return;
+        }
+
+        if (!Array.isArray(data.emailTemplates)) {
+          data.emailTemplates = [];
+        }
+
+        const nowIso = new Date().toISOString();
+        const templateId = editingEmailTemplateId || generateId('email-template');
+        const existingIndex = data.emailTemplates.findIndex(
+          (template) => template && template.id === templateId,
+        );
+        const baseTemplate = existingIndex >= 0 ? data.emailTemplates[existingIndex] : {};
+
+        const normalizedTemplate = normalizeEmailTemplate({
+          ...baseTemplate,
+          id: templateId,
+          name,
+          subject,
+          blocks: normalizedBlocks,
+          createdAt:
+            baseTemplate && typeof baseTemplate.createdAt === 'string' && baseTemplate.createdAt
+              ? baseTemplate.createdAt
+              : nowIso,
+          updatedAt: nowIso,
+        });
+
+        if (existingIndex >= 0) {
+          data.emailTemplates.splice(existingIndex, 1, normalizedTemplate);
+        } else {
+          data.emailTemplates.push(normalizedTemplate);
+        }
+
+        editingEmailTemplateId = normalizedTemplate.id;
+        emailTemplateBlocks = normalizedTemplate.blocks.map((block) => ({ ...block }));
+        emailTemplateNameInput.value = normalizedTemplate.name;
+        emailTemplateSubjectInput.value = normalizedTemplate.subject;
+
+        data.lastUpdated = nowIso;
+        saveDataForUser(currentUser, data);
+
+        renderEmailTemplateBlocks();
+        renderEmailTemplatePreview();
+        renderEmailTemplateList();
+        renderCampaignTemplateOptions(normalizedTemplate.id);
+        updateCampaignRecipientPreview();
+
+        if (emailTemplateFeedback) {
+          emailTemplateFeedback.textContent = `Modèle "${normalizedTemplate.name}" enregistré.`;
+          emailTemplateFeedback.classList.remove('form-feedback--error');
+          emailTemplateFeedback.classList.add('form-feedback--success');
+        }
+      });
+
+      emailTemplateForm.addEventListener('reset', (event) => {
+        if (isResettingEmailTemplateForm) {
+          return;
+        }
+        event.preventDefault();
+        resetEmailTemplateForm();
+      });
+    }
+
+    if (emailTemplateList) {
+      emailTemplateList.addEventListener('click', (event) => {
+        const button =
+          event.target instanceof HTMLElement
+            ? event.target.closest('button[data-template-action]')
+            : null;
+        if (!(button instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        const action = button.dataset.templateAction || '';
+        const templateId = button.dataset.templateId || '';
+        if (!action || !templateId) {
+          return;
+        }
+
+        const template = getEmailTemplateById(templateId);
+        if (!template) {
+          renderEmailTemplateList();
+          return;
+        }
+
+        if (action === 'edit') {
+          loadEmailTemplateIntoForm(template);
+          return;
+        }
+
+        if (action === 'duplicate') {
+          if (!Array.isArray(data.emailTemplates)) {
+            data.emailTemplates = [];
+          }
+          const nowIso = new Date().toISOString();
+          const duplicateName = `${template.name || 'Modèle sans nom'} (copie)`;
+          const duplicatedTemplate = normalizeEmailTemplate({
+            ...template,
+            id: generateId('email-template'),
+            name: duplicateName,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          });
+          data.emailTemplates.push(duplicatedTemplate);
+          data.lastUpdated = nowIso;
+          saveDataForUser(currentUser, data);
+          renderEmailTemplateList();
+          renderCampaignTemplateOptions(duplicatedTemplate.id);
+          if (emailTemplateFeedback) {
+            emailTemplateFeedback.textContent = `Modèle dupliqué sous le nom "${duplicateName}".`;
+            emailTemplateFeedback.classList.remove('form-feedback--error');
+            emailTemplateFeedback.classList.add('form-feedback--success');
+          }
+          return;
+        }
+
+        if (action === 'delete') {
+          if (!window.confirm(`Supprimer le modèle "${template.name}" ?`)) {
+            return;
+          }
+          data.emailTemplates = data.emailTemplates.filter((item) => item && item.id !== templateId);
+          data.lastUpdated = new Date().toISOString();
+          saveDataForUser(currentUser, data);
+          if (editingEmailTemplateId === templateId) {
+            resetEmailTemplateForm();
+          }
+          renderEmailTemplateList();
+          renderCampaignTemplateOptions('');
+          updateCampaignRecipientPreview();
+          if (emailTemplateFeedback) {
+            emailTemplateFeedback.textContent = 'Modèle supprimé.';
+            emailTemplateFeedback.classList.remove('form-feedback--error');
+            emailTemplateFeedback.classList.add('form-feedback--success');
+          }
+        }
+      });
+    }
+
+    if (emailCampaignTemplateSelect instanceof HTMLSelectElement) {
+      emailCampaignTemplateSelect.addEventListener('change', () => {
+        const templateId = emailCampaignTemplateSelect.value || '';
+        const template = getEmailTemplateById(templateId);
+
+        if (emailCampaignSubjectInput instanceof HTMLInputElement) {
+          const currentValue = emailCampaignSubjectInput.value || '';
+          const shouldAutoFill = !campaignSubjectManuallyEdited || currentValue.trim() === '';
+
+          if (shouldAutoFill) {
+            emailCampaignSubjectInput.value = template ? template.subject || '' : '';
+            campaignSubjectManuallyEdited = false;
+          }
+        }
+
+        updateCampaignRecipientPreview();
+        if (emailCampaignFeedback) {
+          emailCampaignFeedback.textContent = '';
+          emailCampaignFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+        }
+      });
+    }
+
+    if (emailCampaignSavedSearchSelect instanceof HTMLSelectElement) {
+      emailCampaignSavedSearchSelect.addEventListener('change', () => {
+        updateCampaignRecipientPreview();
+        if (emailCampaignFeedback) {
+          emailCampaignFeedback.textContent = '';
+          emailCampaignFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+        }
+      });
+    }
+
+    if (emailCampaignSubjectInput instanceof HTMLInputElement) {
+      emailCampaignSubjectInput.addEventListener('input', () => {
+        const value = emailCampaignSubjectInput.value || '';
+        campaignSubjectManuallyEdited = value.trim().length > 0;
+      });
+    }
+
+    if (emailCampaignForm) {
+      emailCampaignForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+
+        if (!(emailCampaignNameInput instanceof HTMLInputElement)) {
+          return;
+        }
+        if (!(emailCampaignSenderEmailInput instanceof HTMLInputElement)) {
+          return;
+        }
+        if (!(emailCampaignSubjectInput instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const name = emailCampaignNameInput.value.trim();
+        const senderName =
+          emailCampaignSenderNameInput instanceof HTMLInputElement
+            ? emailCampaignSenderNameInput.value.trim()
+            : '';
+        const senderEmail = emailCampaignSenderEmailInput.value.trim();
+        const templateId =
+          emailCampaignTemplateSelect instanceof HTMLSelectElement
+            ? emailCampaignTemplateSelect.value || ''
+            : '';
+        const savedSearchId =
+          emailCampaignSavedSearchSelect instanceof HTMLSelectElement
+            ? emailCampaignSavedSearchSelect.value || ''
+            : '';
+        const subject = emailCampaignSubjectInput.value.trim();
+
+        const template = getEmailTemplateById(templateId);
+        const savedSearch = getSavedSearchById(savedSearchId);
+
+        if (!template) {
+          if (emailCampaignFeedback) {
+            emailCampaignFeedback.textContent = 'Sélectionnez un modèle de mail valide.';
+            emailCampaignFeedback.classList.add('form-feedback--error');
+            emailCampaignFeedback.classList.remove('form-feedback--success');
+          }
+          return;
+        }
+
+        if (!savedSearch) {
+          if (emailCampaignFeedback) {
+            emailCampaignFeedback.textContent = 'Sélectionnez une recherche sauvegardée valide.';
+            emailCampaignFeedback.classList.add('form-feedback--error');
+            emailCampaignFeedback.classList.remove('form-feedback--success');
+          }
+          return;
+        }
+
+        const { recipients, contactsWithoutEmail } = computeCampaignRecipients(savedSearch);
+        if (recipients.length === 0) {
+          if (emailCampaignFeedback) {
+            emailCampaignFeedback.textContent =
+              "Aucun destinataire possédant une adresse mail n'a été trouvé pour cette recherche.";
+            emailCampaignFeedback.classList.add('form-feedback--error');
+            emailCampaignFeedback.classList.remove('form-feedback--success');
+          }
+          return;
+        }
+
+        const recipientEmails = recipients
+          .map((recipient) => recipient && recipient.email)
+          .filter((email) => Boolean(email));
+
+        const nowIso = new Date().toISOString();
+
+        if (!Array.isArray(data.emailCampaigns)) {
+          data.emailCampaigns = [];
+        }
+
+        const normalizedCampaign = normalizeEmailCampaign({
+          id: generateId('email-campaign'),
+          name,
+          senderName,
+          senderEmail,
+          templateId: template.id,
+          savedSearchId: savedSearch.id,
+          subject,
+          recipientEmails,
+          contactsWithoutEmail,
+          createdAt: nowIso,
+        });
+
+        data.emailCampaigns.push(normalizedCampaign);
+        data.lastUpdated = nowIso;
+        saveDataForUser(currentUser, data);
+
+        renderCampaignHistory();
+
+        resetEmailCampaignForm();
+
+        if (emailCampaignFeedback) {
+          emailCampaignFeedback.textContent = `Campagne "${normalizedCampaign.name}" préparée pour envoi.`;
+          emailCampaignFeedback.classList.remove('form-feedback--error');
+          emailCampaignFeedback.classList.add('form-feedback--success');
+        }
+      });
+
+      emailCampaignForm.addEventListener('reset', (event) => {
+        if (isResettingEmailCampaignForm) {
+          return;
+        }
+        event.preventDefault();
+        resetEmailCampaignForm();
+      });
+    }
+
+    renderSavedSearchSelect();
+    renderSavedSearchList();
+    renderEmailTemplateBlocks();
+    renderEmailTemplatePreview();
+    renderEmailTemplateList();
+    renderCampaignSavedSearchOptions('');
+    renderCampaignTemplateOptions('');
+    updateCampaignRecipientPreview();
+    renderCampaignHistory();
 
     if (contactSelectAllButton instanceof HTMLButtonElement) {
       contactSelectAllButton.addEventListener('click', () => {
@@ -5891,36 +6512,8 @@
       });
     }
 
-    function renderContacts() {
+    function getFilteredContactsSnapshot(term, filters) {
       const contacts = Array.isArray(data.contacts) ? data.contacts.slice() : [];
-
-      if (contactSearchCountEl) {
-        contactSearchCountEl.textContent = '0';
-      }
-
-      if (!contactList || !contactEmptyState) {
-        return;
-      }
-
-      contactList.innerHTML = '';
-
-      const validContactIds = new Set(
-        contacts
-          .map((contact) => (contact && contact.id ? contact.id : ''))
-          .filter((id) => Boolean(id)),
-      );
-      let selectionChanged = false;
-      selectedContactIds.forEach((id) => {
-        if (!validContactIds.has(id)) {
-          selectedContactIds.delete(id);
-          selectionChanged = true;
-        }
-      });
-      if (selectionChanged) {
-        updateSelectedContactsUI();
-      }
-
-      const normalizedTerm = contactSearchTerm.trim().toLowerCase();
       const categoriesById = buildCategoryMap();
       const keywordsById = new Map(
         Array.isArray(data.keywords)
@@ -5928,15 +6521,16 @@
           : [],
       );
 
+      const normalizedTerm = typeof term === 'string' ? term.trim().toLowerCase() : '';
       const categoryFilterEntries =
-        advancedFilters &&
-        advancedFilters.categories &&
-        typeof advancedFilters.categories === 'object'
-          ? Object.entries(advancedFilters.categories)
+        filters &&
+        filters.categories &&
+        typeof filters.categories === 'object'
+          ? Object.entries(filters.categories)
           : [];
 
-      const keywordFilters = Array.isArray(advancedFilters.keywords)
-        ? advancedFilters.keywords.filter((value) => Boolean(value))
+      const keywordFilters = Array.isArray(filters && filters.keywords)
+        ? filters.keywords.filter((value) => Boolean(value))
         : [];
 
       const hasAdvancedFilters = categoryFilterEntries.length > 0 || keywordFilters.length > 0;
@@ -5944,14 +6538,19 @@
       const filteredContacts = contacts
         .filter((contact) => {
           const categoryValues =
-            contact && typeof contact === 'object' && contact.categoryValues && typeof contact.categoryValues === 'object'
+            contact &&
+            typeof contact === 'object' &&
+            contact.categoryValues &&
+            typeof contact.categoryValues === 'object'
               ? contact.categoryValues
               : {};
           const keywords = Array.isArray(contact.keywords) ? contact.keywords : [];
+
           for (const [categoryId, filter] of categoryFilterEntries) {
             if (!filter || typeof filter !== 'object') {
               continue;
             }
+
             const rawValue = categoryValues[categoryId];
             const valueString =
               rawValue === undefined || rawValue === null ? '' : rawValue.toString().trim();
@@ -5971,8 +6570,7 @@
 
           if (keywordFilters.length > 0) {
             const keywordSet = new Set(keywords);
-            const matchesKeywords = keywordFilters.every((keywordId) => keywordSet.has(keywordId));
-            if (!matchesKeywords) {
+            if (!keywordFilters.every((keywordId) => keywordSet.has(keywordId))) {
               return false;
             }
           }
@@ -5997,7 +6595,7 @@
                 rawValue === undefined || rawValue === null ? '' : rawValue.toString().trim();
               return value ? { name: category.name, value } : null;
             })
-            .filter((entry) => Boolean(entry));
+            .filter(Boolean);
 
           const keywordNames = keywords
             .map((keywordId) => {
@@ -6033,6 +6631,46 @@
           return nameA.localeCompare(nameB, 'fr', { sensitivity: 'base' });
         });
 
+      return {
+        contacts: filteredContacts,
+        normalizedTerm,
+        hasAdvancedFilters,
+        categoriesById,
+      };
+    }
+
+    function renderContacts() {
+      const allContacts = Array.isArray(data.contacts) ? data.contacts.slice() : [];
+
+      if (contactSearchCountEl) {
+        contactSearchCountEl.textContent = '0';
+      }
+
+      if (!contactList || !contactEmptyState) {
+        return;
+      }
+
+      contactList.innerHTML = '';
+
+      const validContactIds = new Set(
+        allContacts
+          .map((contact) => (contact && contact.id ? contact.id : ''))
+          .filter((id) => Boolean(id)),
+      );
+      let selectionChanged = false;
+      selectedContactIds.forEach((id) => {
+        if (!validContactIds.has(id)) {
+          selectedContactIds.delete(id);
+          selectionChanged = true;
+        }
+      });
+      if (selectionChanged) {
+        updateSelectedContactsUI();
+      }
+
+      const snapshot = getFilteredContactsSnapshot(contactSearchTerm, advancedFilters);
+      const { contacts: filteredContacts, normalizedTerm, hasAdvancedFilters, categoriesById } = snapshot;
+
       lastContactSearchResultIds = filteredContacts
         .map((contact) => (contact && contact.id ? contact.id : ''))
         .filter((id) => Boolean(id));
@@ -6051,7 +6689,7 @@
 
       if (totalResults === 0) {
         contactEmptyState.hidden = false;
-        if (contacts.length === 0) {
+        if (allContacts.length === 0) {
           contactEmptyState.textContent = 'Ajoutez vos premiers contacts pour les retrouver ici.';
         } else if (normalizedTerm || hasAdvancedFilters) {
           contactEmptyState.textContent = 'Aucun contact ne correspond à vos critères de recherche.';
@@ -7947,6 +8585,31 @@
         contact.displayName = derivedName || fallbackName || 'Contact sans nom';
       });
 
+      if (!Array.isArray(base.savedSearches)) {
+        base.savedSearches = [];
+      } else {
+        base.savedSearches = base.savedSearches
+          .filter((item) => item && typeof item === 'object')
+          .map((item) => normalizeSavedSearch(item));
+      }
+
+      if (!Array.isArray(base.emailTemplates)) {
+        base.emailTemplates = [];
+      } else {
+        base.emailTemplates = base.emailTemplates
+          .filter((item) => item && typeof item === 'object')
+          .map((item) => normalizeEmailTemplate(item));
+      }
+
+      if (!Array.isArray(base.emailCampaigns)) {
+        base.emailCampaigns = [];
+      } else {
+        base.emailCampaigns = base.emailCampaigns
+          .filter((item) => item && typeof item === 'object')
+          .map((item) => normalizeEmailCampaign(item))
+          .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
+      }
+
       cleanupContactCategoryValues(base);
       updateMetricsFromContacts(base);
 
@@ -7955,6 +8618,1139 @@
       }
 
       return base;
+    }
+
+    function hasActiveAdvancedFilters(filters) {
+      if (!filters || typeof filters !== 'object') {
+        return false;
+      }
+
+      const hasCategoryFilters =
+        filters.categories &&
+        typeof filters.categories === 'object' &&
+        Object.values(filters.categories).some((filter) => {
+          if (!filter || typeof filter !== 'object') {
+            return false;
+          }
+          const rawValue = filter.rawValue != null ? filter.rawValue.toString() : '';
+          return Boolean(rawValue.trim());
+        });
+
+      const hasKeywordFilters =
+        Array.isArray(filters.keywords) && filters.keywords.some((value) => Boolean(value));
+
+      return hasCategoryFilters || hasKeywordFilters;
+    }
+
+    function cloneAdvancedFiltersForStorage(filters) {
+      const result = createEmptyAdvancedFilters();
+      if (!filters || typeof filters !== 'object') {
+        return result;
+      }
+
+      if (filters.categories && typeof filters.categories === 'object') {
+        Object.entries(filters.categories).forEach(([categoryId, filter]) => {
+          if (!categoryId || !filter || typeof filter !== 'object') {
+            return;
+          }
+          const rawValue = filter.rawValue != null ? filter.rawValue.toString() : '';
+          if (!rawValue) {
+            return;
+          }
+
+          const type = CATEGORY_TYPES.has(filter.type) ? filter.type : 'text';
+          const normalizedValue =
+            type === 'text' ? rawValue.toLowerCase() : filter.normalizedValue || rawValue;
+
+          result.categories[categoryId] = {
+            type,
+            rawValue,
+            normalizedValue: normalizedValue != null ? normalizedValue.toString() : rawValue,
+          };
+        });
+      }
+
+      if (Array.isArray(filters.keywords)) {
+        result.keywords = filters.keywords
+          .map((value) => (value != null ? value.toString() : ''))
+          .filter((value) => Boolean(value));
+      }
+
+      return result;
+    }
+
+    function cloneSavedSearchFilters(filters) {
+      const result = createEmptyAdvancedFilters();
+      if (!filters || typeof filters !== 'object') {
+        return result;
+      }
+
+      if (filters.categories && typeof filters.categories === 'object') {
+        Object.entries(filters.categories).forEach(([categoryId, filter]) => {
+          if (!categoryId || !filter || typeof filter !== 'object') {
+            return;
+          }
+
+          const type = CATEGORY_TYPES.has(filter.type) ? filter.type : 'text';
+          const rawValue = filter.rawValue != null ? filter.rawValue.toString() : '';
+          if (!rawValue) {
+            return;
+          }
+
+          let normalizedValue = filter.normalizedValue != null ? filter.normalizedValue.toString() : '';
+          if (!normalizedValue) {
+            normalizedValue = type === 'text' ? rawValue.toLowerCase() : rawValue;
+          }
+
+          result.categories[categoryId] = {
+            type,
+            rawValue,
+            normalizedValue,
+          };
+        });
+      }
+
+      if (Array.isArray(filters.keywords)) {
+        result.keywords = filters.keywords
+          .map((value) => (value != null ? value.toString() : ''))
+          .filter((value) => Boolean(value));
+      }
+
+      return result;
+    }
+
+    function normalizeSavedSearch(item) {
+      const nowIso = new Date().toISOString();
+      const id = typeof item.id === 'string' && item.id ? item.id : generateId('saved-search');
+      const rawName = (item && item.name != null ? item.name : '').toString().trim();
+      const name = rawName || 'Recherche sans nom';
+      const searchTerm = (item && item.searchTerm != null ? item.searchTerm : '').toString();
+      const filters = cloneSavedSearchFilters(item && item.filters);
+      const createdAt =
+        item && typeof item.createdAt === 'string' && item.createdAt ? item.createdAt : nowIso;
+      const updatedAt =
+        item && typeof item.updatedAt === 'string' && item.updatedAt ? item.updatedAt : createdAt;
+
+      return {
+        id,
+        name,
+        searchTerm,
+        filters,
+        createdAt,
+        updatedAt,
+      };
+    }
+
+    const EMAIL_TEMPLATE_BLOCK_TYPES = new Set(['paragraph', 'image', 'button']);
+
+    function normalizeEmailTemplateBlock(block) {
+      if (!block || typeof block !== 'object') {
+        return null;
+      }
+
+      const type = EMAIL_TEMPLATE_BLOCK_TYPES.has(block.type) ? block.type : 'paragraph';
+      const id = typeof block.id === 'string' && block.id ? block.id : generateId('template-block');
+
+      if (type === 'paragraph') {
+        const text = (block.text || '').toString();
+        if (!text.trim()) {
+          return null;
+        }
+        return { id, type, text };
+      }
+
+      if (type === 'image') {
+        const url = (block.url || '').toString().trim();
+        if (!url) {
+          return null;
+        }
+        const alt = (block.alt || '').toString();
+        const linkUrl = (block.linkUrl || '').toString().trim();
+        const caption = (block.caption || '').toString();
+        return { id, type, url, alt, linkUrl, caption };
+      }
+
+      if (type === 'button') {
+        const label = (block.label || '').toString().trim();
+        const linkUrl = (block.linkUrl || '').toString().trim();
+        if (!label || !linkUrl) {
+          return null;
+        }
+        return { id, type, label, linkUrl };
+      }
+
+      return null;
+    }
+
+    function normalizeEmailTemplate(item) {
+      const nowIso = new Date().toISOString();
+      const id = typeof item.id === 'string' && item.id ? item.id : generateId('email-template');
+      const rawName = (item && item.name != null ? item.name : '').toString().trim();
+      const name = rawName || 'Modèle sans nom';
+      const subject = (item && item.subject != null ? item.subject : '').toString().trim();
+      const blocksSource = Array.isArray(item && item.blocks) ? item.blocks : [];
+      const blocks = blocksSource
+        .map((block) => normalizeEmailTemplateBlock(block))
+        .filter((block) => Boolean(block));
+      const createdAt =
+        item && typeof item.createdAt === 'string' && item.createdAt ? item.createdAt : nowIso;
+      const updatedAt =
+        item && typeof item.updatedAt === 'string' && item.updatedAt ? item.updatedAt : createdAt;
+
+      return {
+        id,
+        name,
+        subject,
+        blocks,
+        createdAt,
+        updatedAt,
+      };
+    }
+
+    function normalizeEmailCampaign(item) {
+      const nowIso = new Date().toISOString();
+      const id = typeof item.id === 'string' && item.id ? item.id : generateId('email-campaign');
+      const name = (item && item.name != null ? item.name : '').toString().trim() || 'Campagne sans nom';
+      const senderName = (item && item.senderName != null ? item.senderName : '').toString().trim();
+      const senderEmail = (item && item.senderEmail != null ? item.senderEmail : '').toString().trim();
+      const templateId = (item && item.templateId != null ? item.templateId : '').toString().trim();
+      const savedSearchId =
+        (item && item.savedSearchId != null ? item.savedSearchId : '').toString().trim();
+      const subject = (item && item.subject != null ? item.subject : '').toString().trim();
+      const recipientEmails = Array.isArray(item && item.recipientEmails)
+        ? Array.from(
+            new Set(
+              item.recipientEmails
+                .map((value) => (value != null ? value.toString().trim() : ''))
+                .filter((value) => Boolean(value)),
+            ),
+          )
+        : [];
+      const contactsWithoutEmail = Number.isFinite(item && item.contactsWithoutEmail)
+        ? Math.max(0, Math.floor(item.contactsWithoutEmail))
+        : 0;
+      const createdAt =
+        item && typeof item.createdAt === 'string' && item.createdAt ? item.createdAt : nowIso;
+
+      return {
+        id,
+        name,
+        senderName,
+        senderEmail,
+        templateId,
+        savedSearchId,
+        subject,
+        recipientEmails,
+        recipientCount: recipientEmails.length,
+        contactsWithoutEmail,
+        createdAt,
+      };
+    }
+
+    function setContactSaveSearchFeedback(message, tone = 'info') {
+      if (!contactSaveSearchFeedback) {
+        return;
+      }
+
+      contactSaveSearchFeedback.textContent = message || '';
+      contactSaveSearchFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+      if (!message) {
+        return;
+      }
+
+      if (tone === 'error') {
+        contactSaveSearchFeedback.classList.add('form-feedback--error');
+        return;
+      }
+
+      if (tone === 'success') {
+        contactSaveSearchFeedback.classList.add('form-feedback--success');
+      }
+    }
+
+    function describeSavedSearch(savedSearch) {
+      if (!savedSearch || typeof savedSearch !== 'object') {
+        return '';
+      }
+
+      const parts = [];
+      const searchTerm = (savedSearch.searchTerm || '').toString().trim();
+      if (searchTerm) {
+        parts.push(`Texte libre : "${searchTerm}"`);
+      }
+
+      const categories = savedSearch.filters && savedSearch.filters.categories;
+      if (categories && typeof categories === 'object') {
+        const categoriesById = buildCategoryMap();
+        Object.entries(categories).forEach(([categoryId, filter]) => {
+          if (!categoryId || !filter || typeof filter !== 'object') {
+            return;
+          }
+          const category = categoriesById.get(categoryId);
+          if (!category) {
+            return;
+          }
+          const label = category.name || 'Catégorie';
+          const rawValue = filter.rawValue != null ? filter.rawValue.toString() : '';
+          if (!rawValue) {
+            return;
+          }
+          if (filter.type === 'text') {
+            parts.push(`${label} contient "${rawValue}"`);
+          } else {
+            parts.push(`${label} = ${rawValue}`);
+          }
+        });
+      }
+
+      const keywordIds = savedSearch.filters && savedSearch.filters.keywords;
+      if (Array.isArray(keywordIds) && keywordIds.length > 0) {
+        const keywordsById = new Map(
+          Array.isArray(data.keywords)
+            ? data.keywords.map((keyword) => [keyword.id, keyword])
+            : [],
+        );
+        const keywordNames = keywordIds
+          .map((keywordId) => {
+            const keyword = keywordsById.get(keywordId);
+            return keyword ? keyword.name : '';
+          })
+          .filter((name) => Boolean(name));
+        if (keywordNames.length > 0) {
+          parts.push(`Mots clés : ${keywordNames.join(', ')}`);
+        }
+      }
+
+      if (parts.length === 0) {
+        return 'Tous les contacts sans filtre particulier.';
+      }
+
+      return parts.join(' · ');
+    }
+
+    function getSavedSearchById(savedSearchId) {
+      if (!savedSearchId || !Array.isArray(data.savedSearches)) {
+        return null;
+      }
+      return data.savedSearches.find((search) => search && search.id === savedSearchId) || null;
+    }
+
+    function countContactsForSavedSearch(savedSearch) {
+      if (!savedSearch || typeof savedSearch !== 'object') {
+        return 0;
+      }
+      const snapshot = getFilteredContactsSnapshot(savedSearch.searchTerm, savedSearch.filters || {});
+      return snapshot.contacts.length;
+    }
+
+    function renderSavedSearchSelect(selectedId = lastAppliedSavedSearchId) {
+      if (!(contactSavedSearchSelect instanceof HTMLSelectElement)) {
+        return;
+      }
+
+      const savedSearches = Array.isArray(data.savedSearches)
+        ? data.savedSearches
+            .slice()
+            .filter((item) => item && item.id)
+            .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }))
+        : [];
+
+      contactSavedSearchSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = savedSearches.length === 0
+        ? 'Aucune recherche sauvegardée'
+        : 'Choisir une recherche';
+      contactSavedSearchSelect.appendChild(placeholder);
+
+      savedSearches.forEach((savedSearch) => {
+        const option = document.createElement('option');
+        option.value = savedSearch.id;
+        option.textContent = savedSearch.name;
+        if (savedSearch.id === selectedId) {
+          option.selected = true;
+        }
+        contactSavedSearchSelect.appendChild(option);
+      });
+
+      contactSavedSearchSelect.disabled = savedSearches.length === 0;
+      if (savedSearches.length === 0) {
+        contactSavedSearchSelect.value = '';
+      } else if (selectedId) {
+        contactSavedSearchSelect.value = selectedId;
+      }
+    }
+
+    function applySavedSearchById(savedSearchId, { showFeedback = false, updateSelect = true } = {}) {
+      const savedSearch = getSavedSearchById(savedSearchId);
+      if (!savedSearch) {
+        if (showFeedback) {
+          setContactSaveSearchFeedback("Cette recherche n'existe plus.", 'error');
+        }
+        return false;
+      }
+
+      lastAppliedSavedSearchId = savedSearch.id;
+      const clonedFilters = cloneSavedSearchFilters(savedSearch.filters || {});
+      advancedFilters = clonedFilters;
+      contactSearchTerm = (savedSearch.searchTerm || '').toString();
+      if (contactSearchInput instanceof HTMLInputElement) {
+        contactSearchInput.value = contactSearchTerm;
+      }
+
+      renderSearchCategoryFields();
+      renderSearchKeywordOptions();
+      contactCurrentPage = 1;
+      renderContacts();
+
+      if (updateSelect) {
+        renderSavedSearchSelect(savedSearch.id);
+      }
+
+      if (showFeedback) {
+        setContactSaveSearchFeedback(`Recherche "${savedSearch.name}" appliquée.`, 'success');
+      }
+      return true;
+    }
+
+    function renderSavedSearchList() {
+      if (!savedSearchList) {
+        return;
+      }
+
+      savedSearchList.innerHTML = '';
+      const savedSearches = Array.isArray(data.savedSearches)
+        ? data.savedSearches
+            .slice()
+            .filter((item) => item && item.id)
+            .sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+        : [];
+
+      if (savedSearchCountEl) {
+        savedSearchCountEl.textContent = savedSearches.length.toString();
+      }
+
+      if (savedSearches.length === 0) {
+        if (savedSearchEmptyState) {
+          savedSearchEmptyState.hidden = false;
+        }
+        return;
+      }
+
+      if (savedSearchEmptyState) {
+        savedSearchEmptyState.hidden = true;
+      }
+
+      const fragment = document.createDocumentFragment();
+      savedSearches.forEach((savedSearch) => {
+        const listItem = document.createElement('li');
+        listItem.className = 'saved-search-item';
+        listItem.dataset.savedSearchId = savedSearch.id;
+
+        const header = document.createElement('div');
+        header.className = 'saved-search-header';
+
+        const title = document.createElement('h3');
+        title.className = 'saved-search-name';
+        title.textContent = savedSearch.name;
+
+        const meta = document.createElement('p');
+        meta.className = 'saved-search-meta';
+        const updatedLabel = savedSearch.updatedAt
+          ? `Modifiée le ${savedSearchDateFormatter.format(new Date(savedSearch.updatedAt))}`
+          : 'Jamais appliquée';
+        const contactCount = countContactsForSavedSearch(savedSearch);
+        meta.textContent = `${updatedLabel} · ${numberFormatter.format(contactCount)} contact${
+          contactCount > 1 ? 's' : ''
+        }`;
+
+        header.append(title, meta);
+
+        const summary = document.createElement('p');
+        summary.className = 'saved-search-summary';
+        summary.textContent = describeSavedSearch(savedSearch);
+
+        const actions = document.createElement('div');
+        actions.className = 'saved-search-actions';
+
+        const applyButton = document.createElement('button');
+        applyButton.type = 'button';
+        applyButton.className = 'secondary-button';
+        applyButton.textContent = 'Appliquer';
+        applyButton.dataset.savedSearchAction = 'apply';
+        applyButton.dataset.savedSearchId = savedSearch.id;
+
+        const renameButton = document.createElement('button');
+        renameButton.type = 'button';
+        renameButton.className = 'ghost-button';
+        renameButton.textContent = 'Renommer';
+        renameButton.dataset.savedSearchAction = 'rename';
+        renameButton.dataset.savedSearchId = savedSearch.id;
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'ghost-button ghost-button--danger saved-search-delete';
+        deleteButton.textContent = 'Supprimer';
+        deleteButton.dataset.savedSearchAction = 'delete';
+        deleteButton.dataset.savedSearchId = savedSearch.id;
+
+        actions.append(applyButton, renameButton, deleteButton);
+
+        listItem.append(header, summary, actions);
+        fragment.appendChild(listItem);
+      });
+
+      savedSearchList.appendChild(fragment);
+    }
+
+    function createTemplateBlock(type) {
+      const normalizedType = EMAIL_TEMPLATE_BLOCK_TYPES.has(type) ? type : 'paragraph';
+      if (normalizedType === 'image') {
+        return { id: generateId('template-block'), type: 'image', url: '', alt: '', linkUrl: '', caption: '' };
+      }
+      if (normalizedType === 'button') {
+        return { id: generateId('template-block'), type: 'button', label: '', linkUrl: '' };
+      }
+      return { id: generateId('template-block'), type: 'paragraph', text: '' };
+    }
+
+    function renderEmailTemplateBlocks() {
+      if (!emailTemplateBlocksContainer) {
+        return;
+      }
+
+      emailTemplateBlocksContainer.innerHTML = '';
+
+      if (!Array.isArray(emailTemplateBlocks) || emailTemplateBlocks.length === 0) {
+        const emptyMessage = document.createElement('p');
+        emptyMessage.className = 'empty-state';
+        emptyMessage.textContent = 'Ajoutez un bloc pour commencer la composition du message.';
+        emailTemplateBlocksContainer.appendChild(emptyMessage);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      emailTemplateBlocks.forEach((block, index) => {
+        if (!block || typeof block !== 'object') {
+          return;
+        }
+
+        const wrapper = document.createElement('article');
+        wrapper.className = 'email-template-block';
+        wrapper.dataset.blockId = block.id;
+        wrapper.dataset.blockType = block.type;
+
+        const header = document.createElement('div');
+        header.className = 'email-template-block-header';
+
+        const title = document.createElement('h3');
+        title.textContent = `Bloc ${index + 1}`;
+
+        const controls = document.createElement('div');
+        controls.className = 'email-template-block-controls';
+
+        const moveUpButton = document.createElement('button');
+        moveUpButton.type = 'button';
+        moveUpButton.className = 'ghost-button';
+        moveUpButton.textContent = 'Monter';
+        moveUpButton.dataset.blockAction = 'move-up';
+        moveUpButton.dataset.blockId = block.id;
+        moveUpButton.disabled = index === 0;
+
+        const moveDownButton = document.createElement('button');
+        moveDownButton.type = 'button';
+        moveDownButton.className = 'ghost-button';
+        moveDownButton.textContent = 'Descendre';
+        moveDownButton.dataset.blockAction = 'move-down';
+        moveDownButton.dataset.blockId = block.id;
+        moveDownButton.disabled = index === emailTemplateBlocks.length - 1;
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'ghost-button ghost-button--danger';
+        deleteButton.textContent = 'Supprimer';
+        deleteButton.dataset.blockAction = 'delete';
+        deleteButton.dataset.blockId = block.id;
+
+        controls.append(moveUpButton, moveDownButton, deleteButton);
+        header.append(title, controls);
+        wrapper.appendChild(header);
+
+        if (block.type === 'paragraph') {
+          const textRow = document.createElement('div');
+          textRow.className = 'form-row';
+          const label = document.createElement('label');
+          label.textContent = 'Contenu du paragraphe';
+          const textarea = document.createElement('textarea');
+          textarea.rows = 4;
+          textarea.value = block.text || '';
+          textarea.dataset.blockField = 'text';
+          textarea.dataset.blockId = block.id;
+          textRow.append(label, textarea);
+          wrapper.appendChild(textRow);
+        } else if (block.type === 'image') {
+          const urlRow = document.createElement('div');
+          urlRow.className = 'form-row';
+          const urlLabel = document.createElement('label');
+          urlLabel.textContent = "URL de l'image";
+          const urlInput = document.createElement('input');
+          urlInput.type = 'url';
+          urlInput.placeholder = 'https://exemple.com/image.png';
+          urlInput.value = block.url || '';
+          urlInput.dataset.blockField = 'url';
+          urlInput.dataset.blockId = block.id;
+          urlRow.append(urlLabel, urlInput);
+
+          const altRow = document.createElement('div');
+          altRow.className = 'form-row';
+          const altLabel = document.createElement('label');
+          altLabel.textContent = 'Texte alternatif';
+          const altInput = document.createElement('input');
+          altInput.type = 'text';
+          altInput.value = block.alt || '';
+          altInput.dataset.blockField = 'alt';
+          altInput.dataset.blockId = block.id;
+          altRow.append(altLabel, altInput);
+
+          const linkRow = document.createElement('div');
+          linkRow.className = 'form-row';
+          const linkLabel = document.createElement('label');
+          linkLabel.textContent = "Lien à ouvrir au clic (optionnel)";
+          const linkInput = document.createElement('input');
+          linkInput.type = 'url';
+          linkInput.placeholder = 'https://exemple.com';
+          linkInput.value = block.linkUrl || '';
+          linkInput.dataset.blockField = 'linkUrl';
+          linkInput.dataset.blockId = block.id;
+          linkRow.append(linkLabel, linkInput);
+
+          const captionRow = document.createElement('div');
+          captionRow.className = 'form-row';
+          const captionLabel = document.createElement('label');
+          captionLabel.textContent = 'Légende (optionnelle)';
+          const captionInput = document.createElement('input');
+          captionInput.type = 'text';
+          captionInput.value = block.caption || '';
+          captionInput.dataset.blockField = 'caption';
+          captionInput.dataset.blockId = block.id;
+          captionRow.append(captionLabel, captionInput);
+
+          wrapper.append(urlRow, altRow, linkRow, captionRow);
+        } else if (block.type === 'button') {
+          const labelRow = document.createElement('div');
+          labelRow.className = 'form-row';
+          const labelLabel = document.createElement('label');
+          labelLabel.textContent = 'Texte du bouton';
+          const labelInput = document.createElement('input');
+          labelInput.type = 'text';
+          labelInput.value = block.label || '';
+          labelInput.dataset.blockField = 'label';
+          labelInput.dataset.blockId = block.id;
+          labelRow.append(labelLabel, labelInput);
+
+          const linkRow = document.createElement('div');
+          linkRow.className = 'form-row';
+          const linkLabel = document.createElement('label');
+          linkLabel.textContent = 'Lien du bouton';
+          const linkInput = document.createElement('input');
+          linkInput.type = 'url';
+          linkInput.placeholder = 'https://exemple.com';
+          linkInput.value = block.linkUrl || '';
+          linkInput.dataset.blockField = 'linkUrl';
+          linkInput.dataset.blockId = block.id;
+          linkRow.append(linkLabel, linkInput);
+
+          wrapper.append(labelRow, linkRow);
+        }
+
+        fragment.appendChild(wrapper);
+      });
+
+      emailTemplateBlocksContainer.appendChild(fragment);
+    }
+
+    function renderEmailTemplatePreview(blocks = emailTemplateBlocks, container = emailTemplatePreview) {
+      if (!container) {
+        return;
+      }
+
+      container.innerHTML = '';
+
+      if (!Array.isArray(blocks) || blocks.length === 0) {
+        const emptyMessage = document.createElement('p');
+        emptyMessage.className = 'empty-state';
+        emptyMessage.textContent = 'Ajoutez des blocs pour visualiser le rendu du mail.';
+        container.appendChild(emptyMessage);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      blocks.forEach((block) => {
+        if (!block || typeof block !== 'object') {
+          return;
+        }
+        if (block.type === 'paragraph') {
+          const paragraph = document.createElement('p');
+          paragraph.textContent = block.text || '';
+          fragment.appendChild(paragraph);
+        } else if (block.type === 'image') {
+          const figure = document.createElement('figure');
+          const image = document.createElement('img');
+          image.src = block.url || '';
+          image.alt = block.alt || '';
+          if (block.linkUrl) {
+            const link = document.createElement('a');
+            link.href = block.linkUrl;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.appendChild(image);
+            figure.appendChild(link);
+          } else {
+            figure.appendChild(image);
+          }
+          if (block.caption) {
+            const caption = document.createElement('figcaption');
+            caption.textContent = block.caption;
+            figure.appendChild(caption);
+          }
+          fragment.appendChild(figure);
+        } else if (block.type === 'button') {
+          const buttonWrapper = document.createElement('div');
+          const buttonLink = document.createElement('a');
+          buttonLink.href = block.linkUrl || '#';
+          buttonLink.target = '_blank';
+          buttonLink.rel = 'noopener noreferrer';
+          buttonLink.className = 'email-preview-button';
+          buttonLink.textContent = block.label || 'Appel à l\'action';
+          buttonWrapper.appendChild(buttonLink);
+          fragment.appendChild(buttonWrapper);
+        }
+      });
+
+      container.appendChild(fragment);
+    }
+
+    function resetEmailTemplateForm(preserveEditing = false) {
+      if (emailTemplateForm && !isResettingEmailTemplateForm) {
+        isResettingEmailTemplateForm = true;
+        emailTemplateForm.reset();
+        isResettingEmailTemplateForm = false;
+      }
+      if (!preserveEditing) {
+        editingEmailTemplateId = '';
+      }
+      emailTemplateBlocks = [];
+      renderEmailTemplateBlocks();
+      renderEmailTemplatePreview();
+      if (emailTemplateFeedback) {
+        emailTemplateFeedback.textContent = '';
+        emailTemplateFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+      }
+    }
+
+    function loadEmailTemplateIntoForm(template) {
+      if (!template || typeof template !== 'object') {
+        return;
+      }
+
+      editingEmailTemplateId = template.id || '';
+      if (emailTemplateNameInput instanceof HTMLInputElement) {
+        emailTemplateNameInput.value = template.name || '';
+      }
+      if (emailTemplateSubjectInput instanceof HTMLInputElement) {
+        emailTemplateSubjectInput.value = template.subject || '';
+      }
+
+      emailTemplateBlocks = Array.isArray(template.blocks)
+        ? template.blocks.map((block) => ({ ...block }))
+        : [];
+      renderEmailTemplateBlocks();
+      renderEmailTemplatePreview(emailTemplateBlocks);
+      if (emailTemplateFeedback) {
+        emailTemplateFeedback.textContent = 'Modèle chargé. Vous pouvez le modifier et sauvegarder.';
+        emailTemplateFeedback.classList.remove('form-feedback--error');
+        emailTemplateFeedback.classList.add('form-feedback--success');
+      }
+    }
+
+    function renderEmailTemplateList() {
+      if (!emailTemplateList) {
+        return;
+      }
+
+      emailTemplateList.innerHTML = '';
+
+      const templates = Array.isArray(data.emailTemplates)
+        ? data.emailTemplates
+            .slice()
+            .filter((template) => template && template.id)
+            .sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+        : [];
+
+      if (emailTemplateEmptyState) {
+        emailTemplateEmptyState.hidden = templates.length > 0;
+      }
+
+      if (templates.length === 0) {
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      templates.forEach((template) => {
+        const card = document.createElement('li');
+        card.className = 'email-template-card';
+        card.dataset.templateId = template.id;
+
+        const header = document.createElement('div');
+        header.className = 'email-template-card-header';
+
+        const title = document.createElement('h3');
+        title.textContent = template.name || 'Modèle sans nom';
+
+        const meta = document.createElement('p');
+        meta.className = 'email-template-card-meta';
+        const updatedAt = template.updatedAt
+          ? savedSearchDateFormatter.format(new Date(template.updatedAt))
+          : 'Non daté';
+        meta.textContent = `${template.subject || 'Sans objet'} · ${template.blocks.length} bloc${
+          template.blocks.length > 1 ? 's' : ''
+        } · ${updatedAt}`;
+
+        header.append(title, meta);
+
+        const preview = document.createElement('div');
+        preview.className = 'email-template-card-preview';
+        let previewText = 'Aucun contenu pour le moment.';
+        if (template.blocks.length > 0) {
+          const firstBlock = template.blocks[0];
+          if (firstBlock.type === 'paragraph') {
+            const text = (firstBlock.text || '').toString().trim();
+            previewText = text.length > 0 ? text.slice(0, 120) : 'Paragraphe vide';
+            if (text.length > 120) {
+              previewText = `${previewText}…`;
+            }
+          } else if (firstBlock.type === 'image') {
+            previewText = `Image : ${(firstBlock.url || '').toString().trim() || 'URL manquante'}`;
+          } else if (firstBlock.type === 'button') {
+            previewText = `Bouton : ${(firstBlock.label || '').toString().trim() || 'Sans libellé'}`;
+          }
+        }
+        preview.textContent = previewText;
+
+        const actions = document.createElement('div');
+        actions.className = 'email-template-card-actions';
+
+        const editButton = document.createElement('button');
+        editButton.type = 'button';
+        editButton.className = 'secondary-button';
+        editButton.textContent = 'Modifier';
+        editButton.dataset.templateAction = 'edit';
+        editButton.dataset.templateId = template.id;
+
+        const duplicateButton = document.createElement('button');
+        duplicateButton.type = 'button';
+        duplicateButton.className = 'ghost-button';
+        duplicateButton.textContent = 'Dupliquer';
+        duplicateButton.dataset.templateAction = 'duplicate';
+        duplicateButton.dataset.templateId = template.id;
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'ghost-button ghost-button--danger';
+        deleteButton.textContent = 'Supprimer';
+        deleteButton.dataset.templateAction = 'delete';
+        deleteButton.dataset.templateId = template.id;
+
+        actions.append(editButton, duplicateButton, deleteButton);
+
+        card.append(header, preview, actions);
+        fragment.appendChild(card);
+      });
+
+      emailTemplateList.appendChild(fragment);
+    }
+
+    function getEmailTemplateById(templateId) {
+      if (!templateId || !Array.isArray(data.emailTemplates)) {
+        return null;
+      }
+      return data.emailTemplates.find((template) => template && template.id === templateId) || null;
+    }
+
+    function renderCampaignSavedSearchOptions(selectedId = emailCampaignSavedSearchSelect instanceof HTMLSelectElement
+      ? emailCampaignSavedSearchSelect.value || ''
+      : '') {
+      if (!(emailCampaignSavedSearchSelect instanceof HTMLSelectElement)) {
+        return;
+      }
+
+      const savedSearches = Array.isArray(data.savedSearches)
+        ? data.savedSearches
+            .slice()
+            .filter((item) => item && item.id)
+            .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }))
+        : [];
+
+      emailCampaignSavedSearchSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = savedSearches.length === 0
+        ? 'Aucune recherche disponible'
+        : 'Choisir une recherche';
+      emailCampaignSavedSearchSelect.appendChild(placeholder);
+
+      savedSearches.forEach((savedSearch) => {
+        const option = document.createElement('option');
+        option.value = savedSearch.id;
+        option.textContent = savedSearch.name;
+        if (selectedId && savedSearch.id === selectedId) {
+          option.selected = true;
+        }
+        emailCampaignSavedSearchSelect.appendChild(option);
+      });
+
+      emailCampaignSavedSearchSelect.disabled = savedSearches.length === 0;
+      if (savedSearches.length === 0) {
+        emailCampaignSavedSearchSelect.value = '';
+      } else if (selectedId) {
+        emailCampaignSavedSearchSelect.value = selectedId;
+      }
+    }
+
+    function renderCampaignTemplateOptions(selectedId = emailCampaignTemplateSelect instanceof HTMLSelectElement
+      ? emailCampaignTemplateSelect.value || ''
+      : '') {
+      if (!(emailCampaignTemplateSelect instanceof HTMLSelectElement)) {
+        return;
+      }
+
+      const templates = Array.isArray(data.emailTemplates)
+        ? data.emailTemplates
+            .slice()
+            .filter((template) => template && template.id)
+            .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }))
+        : [];
+
+      emailCampaignTemplateSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = templates.length === 0 ? 'Aucun modèle disponible' : 'Choisir un modèle';
+      emailCampaignTemplateSelect.appendChild(placeholder);
+
+      templates.forEach((template) => {
+        const option = document.createElement('option');
+        option.value = template.id;
+        option.textContent = template.name;
+        if (selectedId && template.id === selectedId) {
+          option.selected = true;
+        }
+        emailCampaignTemplateSelect.appendChild(option);
+      });
+
+      emailCampaignTemplateSelect.disabled = templates.length === 0;
+      if (templates.length === 0) {
+        emailCampaignTemplateSelect.value = '';
+      } else if (selectedId) {
+        emailCampaignTemplateSelect.value = selectedId;
+      }
+    }
+
+    function computeCampaignRecipients(savedSearch) {
+      if (!savedSearch) {
+        return { recipients: [], contactsWithoutEmail: 0 };
+      }
+
+      const snapshot = getFilteredContactsSnapshot(savedSearch.searchTerm, savedSearch.filters || {});
+      const categoriesById = snapshot.categoriesById || buildCategoryMap();
+      const recipientsMap = new Map();
+      let contactsWithoutEmail = 0;
+
+      snapshot.contacts.forEach((contact) => {
+        const channels = computeContactChannels(contact, categoriesById);
+        if (!channels.emails || channels.emails.length === 0) {
+          contactsWithoutEmail += 1;
+          return;
+        }
+
+        const displayName = getContactDisplayName(contact, categoriesById);
+        channels.emails.forEach((email) => {
+          const normalized = email ? email.toString().trim().toLowerCase() : '';
+          if (!normalized) {
+            return;
+          }
+          let entry = recipientsMap.get(normalized);
+          if (!entry) {
+            entry = { email, names: new Set() };
+            recipientsMap.set(normalized, entry);
+          }
+          if (displayName) {
+            entry.names.add(displayName);
+          }
+        });
+      });
+
+      const recipients = Array.from(recipientsMap.values()).map((entry) => ({
+        email: entry.email,
+        names: Array.from(entry.names),
+      }));
+
+      return { recipients, contactsWithoutEmail };
+    }
+
+    function updateCampaignRecipientPreview() {
+      if (!campaignSummaryEl || !campaignRecipientList) {
+        return;
+      }
+
+      const savedSearchId =
+        emailCampaignSavedSearchSelect instanceof HTMLSelectElement
+          ? emailCampaignSavedSearchSelect.value
+          : '';
+      const savedSearch = getSavedSearchById(savedSearchId);
+
+      const templateId =
+        emailCampaignTemplateSelect instanceof HTMLSelectElement
+          ? emailCampaignTemplateSelect.value
+          : '';
+      const template = getEmailTemplateById(templateId);
+
+      if (template) {
+        renderEmailTemplatePreview(template.blocks, campaignEmailPreview);
+      } else {
+        renderEmailTemplatePreview([], campaignEmailPreview);
+      }
+
+      campaignRecipientList.innerHTML = '';
+
+      if (!savedSearch) {
+        campaignSummaryEl.textContent =
+          'Sélectionnez une recherche sauvegardée pour afficher les contacts concernés.';
+        return;
+      }
+
+      const { recipients, contactsWithoutEmail } = computeCampaignRecipients(savedSearch);
+
+      if (recipients.length === 0) {
+        campaignSummaryEl.textContent =
+          contactsWithoutEmail > 0
+            ? 'Aucun contact ne possède d\'adresse mail pour cette recherche.'
+            : 'Aucun contact trouvé pour la recherche sélectionnée.';
+        return;
+      }
+
+      campaignSummaryEl.textContent = `${numberFormatter.format(
+        recipients.length,
+      )} destinataire${recipients.length > 1 ? 's' : ''} seront contactés.`;
+      if (contactsWithoutEmail > 0) {
+        campaignSummaryEl.textContent += ` ${numberFormatter.format(
+          contactsWithoutEmail,
+        )} contact${contactsWithoutEmail > 1 ? 's' : ''} sans mail sont ignorés.`;
+      }
+
+      const fragment = document.createDocumentFragment();
+      recipients.forEach((recipient) => {
+        const item = document.createElement('li');
+        item.className = 'campaign-recipient-item';
+
+        const emailLine = document.createElement('p');
+        emailLine.className = 'campaign-recipient-email';
+        emailLine.textContent = recipient.email;
+
+        item.appendChild(emailLine);
+
+        if (recipient.names && recipient.names.length > 0) {
+          const nameLine = document.createElement('p');
+          nameLine.className = 'campaign-recipient-name';
+          nameLine.textContent = recipient.names.join(', ');
+          item.appendChild(nameLine);
+        }
+
+        fragment.appendChild(item);
+      });
+
+      campaignRecipientList.appendChild(fragment);
+    }
+
+    function resetEmailCampaignForm() {
+      if (emailCampaignForm && !isResettingEmailCampaignForm) {
+        isResettingEmailCampaignForm = true;
+        emailCampaignForm.reset();
+        isResettingEmailCampaignForm = false;
+      }
+      campaignSubjectManuallyEdited = false;
+      renderCampaignSavedSearchOptions('');
+      renderCampaignTemplateOptions('');
+      if (emailCampaignFeedback) {
+        emailCampaignFeedback.textContent = '';
+        emailCampaignFeedback.classList.remove('form-feedback--error', 'form-feedback--success');
+      }
+      if (campaignSummaryEl) {
+        campaignSummaryEl.textContent =
+          'Sélectionnez une recherche sauvegardée pour afficher les contacts concernés.';
+      }
+      if (campaignRecipientList) {
+        campaignRecipientList.innerHTML = '';
+      }
+      renderEmailTemplatePreview([], campaignEmailPreview);
+    }
+
+    function renderCampaignHistory() {
+      if (!campaignHistoryList) {
+        return;
+      }
+
+      campaignHistoryList.innerHTML = '';
+
+      const campaigns = Array.isArray(data.emailCampaigns)
+        ? data.emailCampaigns
+            .slice()
+            .filter((campaign) => campaign && campaign.id)
+            .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''))
+        : [];
+
+      if (campaignHistoryEmptyState) {
+        campaignHistoryEmptyState.hidden = campaigns.length > 0;
+      }
+
+      if (campaigns.length === 0) {
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      campaigns.forEach((campaign) => {
+        const item = document.createElement('li');
+        item.className = 'campaign-history-item';
+
+        const title = document.createElement('h3');
+        title.className = 'campaign-history-title';
+        title.textContent = campaign.name || 'Campagne sans nom';
+
+        const meta = document.createElement('p');
+        meta.className = 'campaign-history-meta';
+        const template = getEmailTemplateById(campaign.templateId);
+        const savedSearch = getSavedSearchById(campaign.savedSearchId);
+        const dateLabel = campaign.createdAt
+          ? emailCampaignDateFormatter.format(new Date(campaign.createdAt))
+          : 'Date inconnue';
+        meta.textContent = `${dateLabel} · ${numberFormatter.format(
+          campaign.recipientCount || 0,
+        )} destinataire${campaign.recipientCount > 1 ? 's' : ''}`;
+
+        const summary = document.createElement('p');
+        summary.className = 'campaign-history-summary';
+        summary.textContent = `${campaign.subject || 'Sans objet'} · Modèle : ${
+          template ? template.name : '—'
+        } · Recherche : ${savedSearch ? savedSearch.name : '—'}`;
+
+        item.append(title, meta, summary);
+        fragment.appendChild(item);
+      });
+
+      campaignHistoryList.appendChild(fragment);
     }
 
     function createEmptyAdvancedFilters() {
@@ -8076,6 +9872,9 @@
                         teamChatMessages: Array.isArray(base.teamChatMessages)
                           ? base.teamChatMessages
                           : [],
+                        savedSearches: Array.isArray(base.savedSearches) ? base.savedSearches : [],
+                        emailTemplates: Array.isArray(base.emailTemplates) ? base.emailTemplates : [],
+                        emailCampaigns: Array.isArray(base.emailCampaigns) ? base.emailCampaigns : [],
                         lastUpdated: base.lastUpdated || null,
 
                         // si jamais ces champs n’existaient pas encore
@@ -8105,20 +9904,23 @@
   }
 
   function cloneDefaultData() {
-	  return {
-		metrics: { ...defaultData.metrics },
-                categories: [],
-                keywords: [],
-                contacts: [],
-                events: [],
-                taskCategories: [],
-                tasks: [],
-                teamChatMessages: [],
-                lastUpdated: null,
-                // Nouveaux champs persistés
-                panelOwner: '',
-                teamMembers: [],
-          };
+    return {
+      metrics: { ...defaultData.metrics },
+      categories: [],
+      keywords: [],
+      contacts: [],
+      events: [],
+      taskCategories: [],
+      tasks: [],
+      teamChatMessages: [],
+      savedSearches: [],
+      emailTemplates: [],
+      emailCampaigns: [],
+      lastUpdated: null,
+      // Nouveaux champs persistés
+      panelOwner: '',
+      teamMembers: [],
+    };
 	}
 
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -134,6 +134,26 @@ button {
   background: rgba(15, 23, 42, 0.14);
 }
 
+.ghost-button {
+  padding: 0;
+  background: none;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  text-decoration: underline;
+}
+
+.ghost-button:focus-visible {
+  outline: none;
+}
+
+.ghost-button--danger {
+  color: var(--color-danger);
+}
+
 .app {
   display: flex;
   flex-direction: column;
@@ -1593,6 +1613,22 @@ button {
   font-size: 0.9rem;
 }
 
+.form-feedback {
+  min-height: 20px;
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.form-feedback--error {
+  color: var(--color-danger);
+}
+
+.form-feedback--success {
+  color: var(--color-primary);
+}
+
 .form-actions {
   display: flex;
   gap: 12px;
@@ -1671,6 +1707,20 @@ button {
   align-items: center;
 }
 
+.contact-saved-searches {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 220px;
+}
+
+.contact-saved-searches label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
 .contact-search-controls input,
 .contact-search-controls select {
   flex: 1 1 220px;
@@ -1682,6 +1732,11 @@ button {
 
 .contact-search-controls select {
   max-width: 280px;
+}
+
+.contact-saved-searches select {
+  max-width: none;
+  width: 100%;
 }
 
 .contact-bulk-actions {
@@ -1847,6 +1902,364 @@ button {
   font-weight: 600;
   background: #fff;
   color: var(--color-text);
+}
+
+.saved-searches-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.saved-searches-description {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 18px 22px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.saved-searches-description p + p {
+  margin-top: 10px;
+}
+
+.saved-search-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.saved-search-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.saved-search-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.saved-search-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.saved-search-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.saved-search-summary {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.saved-search-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.saved-search-actions .secondary-button {
+  padding: 10px 16px;
+}
+
+.saved-search-delete {
+  margin-left: auto;
+}
+
+.email-template-layout,
+.email-campaign-layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  align-items: flex-start;
+}
+
+.email-template-form,
+.email-campaign-form {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 24px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.email-template-block-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.email-template-block-actions span {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.email-template-blocks {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.email-template-block {
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  background: rgba(37, 99, 235, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.email-template-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.email-template-block-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.email-template-block-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.email-template-block textarea {
+  min-height: 120px;
+}
+
+.email-template-preview,
+.email-campaign-preview {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.email-preview {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(248, 250, 252, 0.6);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.email-preview p {
+  margin: 0;
+}
+
+.email-preview figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.email-preview img {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  display: block;
+}
+
+.email-preview figcaption {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.email-preview-button {
+  display: inline-block;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-decoration: none;
+  text-align: center;
+}
+
+.email-preview-button:hover {
+  background: var(--color-primary-dark);
+}
+
+.email-template-list-wrapper {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.email-template-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.email-template-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.email-template-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.email-template-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.email-template-card-meta {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.email-template-card-preview {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  background: rgba(248, 250, 252, 0.6);
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.email-template-card-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.campaign-summary {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.campaign-recipient-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.campaign-recipient-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.campaign-recipient-email {
+  margin: 0;
+  font-weight: 600;
+}
+
+.campaign-recipient-name {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.campaign-history {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.campaign-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.campaign-history-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.campaign-history-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.campaign-history-meta {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.campaign-history-summary {
+  margin: 0;
+  color: var(--color-text-secondary);
 }
 
 .contact-item {
@@ -2865,6 +3278,11 @@ button {
 }
 
 @media (max-width: 1200px) {
+  .email-template-layout,
+  .email-campaign-layout {
+    grid-template-columns: 1fr;
+  }
+
   .import-mapping {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/dashboard.html
+++ b/dashboard.html
@@ -27,6 +27,9 @@
           <button class="topbar-button" type="button" data-top-target="directory">
             Répertoire
           </button>
+          <button class="topbar-button" type="button" data-top-target="communication">
+            Communication
+          </button>
           <button class="topbar-button" type="button" data-top-target="team" id="topbar-team">
             Équipe
           </button>
@@ -589,7 +592,17 @@
                   placeholder="Rechercher par valeur de catégorie, note ou mot clé"
                   autocomplete="off"
                 />
+                <button type="button" class="secondary-button" id="contact-save-search">
+                  Enregistrer la recherche
+                </button>
+                <div class="contact-saved-searches">
+                  <label for="contact-saved-searches">Recherches sauvegardées</label>
+                  <select id="contact-saved-searches">
+                    <option value="">Aucune recherche sélectionnée</option>
+                  </select>
+                </div>
               </div>
+              <p id="contact-save-search-feedback" class="form-feedback" aria-live="polite"></p>
               <form id="contact-advanced-search" class="contact-advanced-search" autocomplete="off">
                 <div class="advanced-grid" id="search-category-fields" aria-live="polite"></div>
                 <p id="search-categories-empty" class="empty-state" hidden>
@@ -668,6 +681,182 @@
                 </select>
               </label>
             </nav>
+          </section>
+
+          <section id="saved-searches" class="page" aria-labelledby="saved-searches-title">
+            <header class="page-header">
+              <div>
+                <h1 id="saved-searches-title">Recherches sauvegardées</h1>
+                <p class="page-subtitle">
+                  Conservez vos filtres favoris pour les réutiliser en un clic ou les partager avec votre équipe.
+                </p>
+              </div>
+              <div class="insight-card">
+                <span class="insight-label">Recherches actives</span>
+                <span class="insight-value" id="saved-search-count">0</span>
+              </div>
+            </header>
+            <div class="saved-searches-content">
+              <div class="saved-searches-description">
+                <p>
+                  Enregistrez une recherche depuis la page de consultation des contacts puis retrouvez-la ici pour
+                  l'appliquer rapidement ou l'utiliser dans vos campagnes de communication.
+                </p>
+                <p>
+                  Pour mettre à jour une recherche, appliquez-la, ajustez les filtres puis enregistrez-la à nouveau avec
+                  le même nom.
+                </p>
+              </div>
+              <ul id="saved-search-list" class="saved-search-list" aria-live="polite"></ul>
+              <p id="saved-search-empty" class="empty-state" hidden>
+                Aucune recherche sauvegardée pour le moment. Créez-en depuis la recherche de contacts.
+              </p>
+            </div>
+          </section>
+
+          <section id="email-templates" class="page" aria-labelledby="email-templates-title">
+            <header class="page-header">
+              <div>
+                <h1 id="email-templates-title">Créer un modèle mail</h1>
+                <p class="page-subtitle">
+                  Composez vos messages types, ajoutez des images cliquables et préparez vos campagnes à l'avance.
+                </p>
+              </div>
+            </header>
+            <div class="email-template-layout">
+              <form id="email-template-form" class="email-template-form" autocomplete="off">
+                <div class="form-row">
+                  <label for="email-template-name">Nom du modèle *</label>
+                  <input id="email-template-name" name="email-template-name" type="text" required maxlength="120" />
+                </div>
+                <div class="form-row">
+                  <label for="email-template-subject">Objet du mail *</label>
+                  <input
+                    id="email-template-subject"
+                    name="email-template-subject"
+                    type="text"
+                    maxlength="140"
+                    required
+                  />
+                </div>
+                <div class="email-template-block-actions">
+                  <span>Ajouter un bloc&nbsp;:</span>
+                  <button type="button" class="secondary-button" id="email-template-add-paragraph">
+                    Paragraphe
+                  </button>
+                  <button type="button" class="secondary-button" id="email-template-add-image">Image</button>
+                  <button type="button" class="secondary-button" id="email-template-add-button">
+                    Bouton d'appel à l'action
+                  </button>
+                </div>
+                <p class="form-hint">
+                  Les images peuvent être liées à une adresse web. Les destinataires ouvriront le lien associé lors d'un
+                  clic sur l'image.
+                </p>
+                <div id="email-template-blocks" class="email-template-blocks" aria-live="polite">
+                  <p class="empty-state">Ajoutez un bloc pour commencer la composition du message.</p>
+                </div>
+                <p id="email-template-feedback" class="form-feedback" aria-live="polite"></p>
+                <div class="form-actions">
+                  <button type="submit" class="primary-button">Enregistrer le modèle</button>
+                  <button type="reset" class="secondary-button">Réinitialiser</button>
+                </div>
+              </form>
+              <aside class="email-template-preview" aria-label="Prévisualisation du modèle">
+                <h2>Prévisualisation</h2>
+                <div id="email-template-preview" class="email-preview" aria-live="polite">
+                  <p class="empty-state">Ajoutez des blocs pour visualiser le rendu du mail.</p>
+                </div>
+              </aside>
+            </div>
+            <section class="email-template-list-wrapper" aria-labelledby="email-template-list-title">
+              <h2 id="email-template-list-title">Modèles enregistrés</h2>
+              <ul id="email-template-list" class="email-template-list" aria-live="polite"></ul>
+              <p id="email-template-empty" class="empty-state" hidden>Aucun modèle n'a encore été enregistré.</p>
+            </section>
+          </section>
+
+          <section id="email-campaigns" class="page" aria-labelledby="email-campaigns-title">
+            <header class="page-header">
+              <div>
+                <h1 id="email-campaigns-title">Envoyer une campagne de mail</h1>
+                <p class="page-subtitle">
+                  Sélectionnez un modèle et une recherche sauvegardée pour informer rapidement tous les contacts ciblés.
+                </p>
+              </div>
+            </header>
+            <div class="email-campaign-layout">
+              <form id="email-campaign-form" class="email-campaign-form" autocomplete="off">
+                <div class="form-row">
+                  <label for="email-campaign-name">Nom de la campagne *</label>
+                  <input id="email-campaign-name" name="email-campaign-name" type="text" required maxlength="120" />
+                </div>
+                <div class="form-row">
+                  <label for="email-campaign-sender-name">Nom de l'expéditeur</label>
+                  <input
+                    id="email-campaign-sender-name"
+                    name="email-campaign-sender-name"
+                    type="text"
+                    maxlength="120"
+                  />
+                </div>
+                <div class="form-row">
+                  <label for="email-campaign-sender-email">Adresse mail de l'expéditeur *</label>
+                  <input
+                    id="email-campaign-sender-email"
+                    name="email-campaign-sender-email"
+                    type="email"
+                    autocomplete="email"
+                    required
+                  />
+                </div>
+                <div class="form-row">
+                  <label for="campaign-template-select">Modèle à utiliser *</label>
+                  <select id="campaign-template-select" name="campaign-template-select" required></select>
+                </div>
+                <div class="form-row">
+                  <label for="campaign-saved-search-select">Recherche sauvegardée *</label>
+                  <select id="campaign-saved-search-select" name="campaign-saved-search-select" required></select>
+                </div>
+                <div class="form-row">
+                  <label for="email-campaign-subject">Objet de la campagne *</label>
+                  <input
+                    id="email-campaign-subject"
+                    name="email-campaign-subject"
+                    type="text"
+                    maxlength="140"
+                    required
+                  />
+                </div>
+                <p class="form-hint">
+                  Seuls les contacts disposant d'une adresse mail valide dans la recherche sélectionnée recevront le
+                  message.
+                </p>
+                <p id="email-campaign-feedback" class="form-feedback" aria-live="polite"></p>
+                <div class="form-actions">
+                  <button type="submit" class="primary-button">Lancer la campagne</button>
+                  <button type="reset" class="secondary-button">Réinitialiser</button>
+                </div>
+              </form>
+              <aside class="email-campaign-preview" aria-label="Prévisualisation de la campagne">
+                <h2>Destinataires ciblés</h2>
+                <p id="campaign-summary" class="campaign-summary">
+                  Sélectionnez une recherche sauvegardée pour afficher les contacts concernés.
+                </p>
+                <ul id="campaign-recipient-list" class="campaign-recipient-list" aria-live="polite"></ul>
+                <h2>Prévisualisation du mail</h2>
+                <div id="campaign-email-preview" class="email-preview" aria-live="polite">
+                  <p class="empty-state">Choisissez un modèle pour afficher un aperçu.</p>
+                </div>
+              </aside>
+            </div>
+            <section class="campaign-history" aria-labelledby="campaign-history-title">
+              <h2 id="campaign-history-title">Campagnes envoyées</h2>
+              <ul id="campaign-history-list" class="campaign-history-list" aria-live="polite"></ul>
+              <p id="campaign-history-empty" class="empty-state" hidden>
+                Aucune campagne n'a encore été envoyée.
+              </p>
+            </section>
           </section>
 
           <section id="team" class="page" aria-labelledby="team-title">


### PR DESCRIPTION
## Summary
- ajoute la navigation Communication et les sections de recherche sauvegardée, de modèles et de campagnes dans le tableau de bord
- étend les styles pour les listes de recherches, le constructeur de modèles d’e-mail et la prévisualisation des campagnes
- implémente la persistance des recherches, l’éditeur de modèles (avec blocs) et l’envoi de campagnes avec prévisualisation et historique

## Testing
- not run (non disponible)


------
https://chatgpt.com/codex/tasks/task_e_68ce8e46b3c48326ae9aa42b30de4ccc