### PR TITLE
Fix UTF-8 fallback without Number.parseInt

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10115,8 +10115,7 @@
 
     if (cryptoObj && cryptoObj.subtle && typeof cryptoObj.subtle.digest === 'function') {
       try {
-        const encoder = new TextEncoder();
-        const dataBuffer = encoder.encode(message);
+        const dataBuffer = encodeUtf8(message);
         const hashBuffer = await cryptoObj.subtle.digest('SHA-256', dataBuffer);
         return bufferToHex(hashBuffer);
       } catch (error) {
@@ -10125,6 +10124,76 @@
     }
 
     return sha256Sync(message);
+  }
+
+  function encodeUtf8(message) {
+    const normalized = message == null ? '' : String(message);
+
+    if (typeof window !== 'undefined' && window.TextEncoder) {
+      try {
+        return new window.TextEncoder().encode(normalized);
+      } catch (error) {
+        // Ignore and use manual fallback below.
+      }
+    }
+
+    if (typeof TextEncoder === 'function') {
+      try {
+        return new TextEncoder().encode(normalized);
+      } catch (error) {
+        // Ignore and use manual fallback below.
+      }
+    }
+
+    const bytes = [];
+    for (let index = 0; index < normalized.length; index += 1) {
+      const codePoint = normalized.charCodeAt(index);
+
+      if (codePoint < 0x80) {
+        bytes.push(codePoint);
+        continue;
+      }
+
+      if (codePoint < 0x800) {
+        bytes.push((codePoint >> 6) | 0xc0, (codePoint & 0x3f) | 0x80);
+        continue;
+      }
+
+      if (codePoint >= 0xd800 && codePoint <= 0xdbff) {
+        const nextIndex = index + 1;
+        if (nextIndex < normalized.length) {
+          const nextCodePoint = normalized.charCodeAt(nextIndex);
+          if (nextCodePoint >= 0xdc00 && nextCodePoint <= 0xdfff) {
+            const combined =
+              ((codePoint - 0xd800) << 10) + (nextCodePoint - 0xdc00) + 0x10000;
+            bytes.push(
+              0xf0 | ((combined >> 18) & 0x07),
+              0x80 | ((combined >> 12) & 0x3f),
+              0x80 | ((combined >> 6) & 0x3f),
+              0x80 | (combined & 0x3f),
+            );
+            index = nextIndex;
+            continue;
+          }
+        }
+
+        bytes.push(0xef, 0xbf, 0xbd);
+        continue;
+      }
+
+      if (codePoint >= 0xdc00 && codePoint <= 0xdfff) {
+        bytes.push(0xef, 0xbf, 0xbd);
+        continue;
+      }
+
+      bytes.push(
+        (codePoint >> 12) | 0xe0,
+        ((codePoint >> 6) & 0x3f) | 0x80,
+        (codePoint & 0x3f) | 0x80,
+      );
+    }
+
+    return new Uint8Array(bytes);
   }
 
   function bufferToHex(buffer) {
@@ -10147,20 +10216,17 @@
       0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
     ]);
 
-    const encoder = new TextEncoder();
-    const messageBytes = encoder.encode(message);
-    const bitLength = BigInt(messageBytes.length) * 8n;
+    const messageBytes = encodeUtf8(message);
     const paddedLength = (((messageBytes.length + 9 + 63) >> 6) << 6);
-
     const buffer = new Uint8Array(paddedLength);
     buffer.set(messageBytes);
     buffer[messageBytes.length] = 0x80;
 
     const view = new DataView(buffer.buffer);
-    const highBits = Number((bitLength >> 32n) & 0xffffffffn);
-    const lowBits = Number(bitLength & 0xffffffffn);
-    view.setUint32(paddedLength - 8, highBits);
-    view.setUint32(paddedLength - 4, lowBits);
+    const bitLenHi = Math.floor(messageBytes.length / 0x20000000);
+    const bitLenLo = (messageBytes.length << 3) >>> 0;
+    view.setUint32(paddedLength - 8, bitLenHi);
+    view.setUint32(paddedLength - 4, bitLenLo);
 
     let h0 = 0x6a09e667;
     let h1 = 0xbb67ae85;
@@ -10173,15 +10239,25 @@
 
     const w = new Uint32Array(64);
 
-    for (let i = 0; i < paddedLength; i += 64) {
-      for (let j = 0; j < 16; j += 1) {
-        w[j] = view.getUint32(i + j * 4);
+    function rightRotate(value, amount) {
+      return ((value >>> amount) | (value << (32 - amount))) >>> 0;
+    }
+
+    for (let offset = 0; offset < buffer.length; offset += 64) {
+      for (let index = 0; index < 16; index += 1) {
+        w[index] = view.getUint32(offset + index * 4);
       }
 
-      for (let j = 16; j < 64; j += 1) {
-        const s0 = rightRotate(w[j - 15], 7) ^ rightRotate(w[j - 15], 18) ^ (w[j - 15] >>> 3);
-        const s1 = rightRotate(w[j - 2], 17) ^ rightRotate(w[j - 2], 19) ^ (w[j - 2] >>> 10);
-        w[j] = (w[j - 16] + s0 + w[j - 7] + s1) >>> 0;
+      for (let index = 16; index < 64; index += 1) {
+        const s0 =
+          rightRotate(w[index - 15], 7) ^
+          rightRotate(w[index - 15], 18) ^
+          (w[index - 15] >>> 3);
+        const s1 =
+          rightRotate(w[index - 2], 17) ^
+          rightRotate(w[index - 2], 19) ^
+          (w[index - 2] >>> 10);
+        w[index] = (w[index - 16] + s0 + w[index - 7] + s1) >>> 0;
       }
 
       let a = h0;
@@ -10193,11 +10269,13 @@
       let g = h6;
       let h = h7;
 
-      for (let j = 0; j < 64; j += 1) {
-        const S1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+      for (let index = 0; index < 64; index += 1) {
+        const S1 =
+          rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
         const ch = (e & f) ^ (~e & g);
-        const temp1 = (h + S1 + ch + k[j] + w[j]) >>> 0;
-        const S0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+        const temp1 = (h + S1 + ch + k[index] + w[index]) >>> 0;
+        const S0 =
+          rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
         const maj = (a & b) ^ (a & c) ^ (b & c);
         const temp2 = (S0 + maj) >>> 0;
 
@@ -10233,10 +10311,6 @@
     hashView.setUint32(28, h7);
 
     return bufferToHex(hash.buffer);
-  }
-
-  function rightRotate(value, amount) {
-    return (value >>> amount) | (value << (32 - amount));
   }
 
   function isValidEmail(value) {


### PR DESCRIPTION
## Summary
- replace the encodeURIComponent-based UTF-8 fallback with a manual encoder that supports surrogate pairs without relying on Number.parseInt
- keep the TextEncoder fast-path while ensuring legacy browsers without TextEncoder or Number.parseInt no longer throw during initialization

## Testing
- node - <<'NODE' (script verifying the manual UTF-8 encoder keeps the SHA-256 fallback aligned with Node.js crypto and WebCrypto)


------
https://chatgpt.com/codex/tasks/task_e_68ce9c30c64c8326b4067268dcc8f48a