### PR TITLE
Add keyword combination mode to contact search

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1814,6 +1814,44 @@ button {
   justify-content: flex-end;
 }
 
+.advanced-keywords {
+  gap: 16px;
+}
+
+.advanced-keywords-list .checkbox-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.advanced-keywords-list .checkbox-item input[type='checkbox'] {
+  flex-shrink: 0;
+}
+
+.advanced-keywords-empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.advanced-keywords-mode {
+  gap: 10px;
+}
+
+.advanced-keywords-mode .choice-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+}
+
+.advanced-keywords-mode .choice-option span {
+  flex: 1;
+}
+
+.advanced-keywords-mode input[type='radio'] {
+  width: 18px;
+  height: 18px;
+}
+
 .secondary-button {
   align-self: flex-start;
   background: rgba(15, 23, 42, 0.08);
@@ -1826,10 +1864,6 @@ button {
 
 .secondary-button:hover {
   background: rgba(15, 23, 42, 0.12);
-}
-
-.advanced-multiselect select {
-  min-height: 120px;
 }
 
 .contact-list {

--- a/dashboard.html
+++ b/dashboard.html
@@ -608,9 +608,22 @@
                 <p id="search-categories-empty" class="empty-state" hidden>
                   Ajoutez vos premières catégories pour filtrer vos contacts.
                 </p>
-                <div class="form-row advanced-multiselect">
-                  <label for="search-keywords">Sélectionnez mes mots clés</label>
-                  <select id="search-keywords" name="search-keywords" multiple></select>
+                <div class="form-row advanced-keywords">
+                  <fieldset class="form-fieldset advanced-keywords-list">
+                    <legend>Sélectionnez mes mots clés</legend>
+                    <div id="search-keywords" class="checkbox-grid"></div>
+                  </fieldset>
+                  <fieldset id="search-keyword-mode" class="form-fieldset advanced-keywords-mode">
+                    <legend>Combiner les mots clés</legend>
+                    <label class="choice-option">
+                      <input type="radio" name="search-keyword-mode" value="all" checked />
+                      <span>ET — tous les mots clés sélectionnés</span>
+                    </label>
+                    <label class="choice-option">
+                      <input type="radio" name="search-keyword-mode" value="any" />
+                      <span>OU — au moins un des mots clés sélectionnés</span>
+                    </label>
+                  </fieldset>
                 </div>
                 <div class="advanced-actions">
                   <button type="submit" class="primary-button">Appliquer les filtres</button>


### PR DESCRIPTION
## Summary
- replace the keyword multiselect in the contact search with a checkbox grid and AND/OR mode selector
- persist the chosen keyword combination mode in advanced filters and saved searches
- adjust filtering logic, saved search summaries and styles to support the new UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec9a25ae883269c8d1dea3bc6df61