### PR TITLE
Implement user registration API and UI flow

### DIFF
--- a/api/register.php
+++ b/api/register.php
@@ -1,0 +1,115 @@
+<?php
+require __DIR__.'/config.php';
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+  http_response_code(405);
+  header('Allow: POST');
+  echo json_encode(['error' => 'method_not_allowed']);
+  exit;
+}
+
+$raw = file_get_contents('php://input');
+$data = json_decode($raw, true);
+
+if (!is_array($data)) {
+  http_response_code(400);
+  echo json_encode(['error' => 'invalid_json']);
+  exit;
+}
+
+$username = trim((string)($data['username'] ?? ''));
+$email = trim((string)($data['email'] ?? ''));
+$password = (string)($data['password'] ?? '');
+
+if ($username === '' || $email === '' || $password === '') {
+  http_response_code(400);
+  echo json_encode(['error' => 'missing_fields']);
+  exit;
+}
+
+if (strlen($username) < 3 || strlen($username) > 50) {
+  http_response_code(400);
+  echo json_encode(['error' => 'invalid_username']);
+  exit;
+}
+
+if (!preg_match('/^[A-Za-z0-9._-]+$/', $username)) {
+  http_response_code(400);
+  echo json_encode(['error' => 'invalid_username']);
+  exit;
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+  http_response_code(400);
+  echo json_encode(['error' => 'invalid_email']);
+  exit;
+}
+
+if (strlen($password) < 6) {
+  http_response_code(400);
+  echo json_encode(['error' => 'password_too_short']);
+  exit;
+}
+
+$lowerEmail = strtolower($email);
+
+$checkEmail = $pdo->prepare('SELECT id FROM users WHERE LOWER(email)=? LIMIT 1');
+$checkEmail->execute([$lowerEmail]);
+if ($checkEmail->fetch()) {
+  http_response_code(409);
+  echo json_encode(['error' => 'email_already_used']);
+  exit;
+}
+
+$checkUsername = $pdo->prepare('SELECT id FROM users WHERE username=? LIMIT 1');
+$checkUsername->execute([$username]);
+if ($checkUsername->fetch()) {
+  http_response_code(409);
+  echo json_encode(['error' => 'username_already_used']);
+  exit;
+}
+
+$passwordHash = password_hash($password, PASSWORD_DEFAULT);
+
+try {
+  $insert = $pdo->prepare('INSERT INTO users (username, email, pass_hash) VALUES (?, ?, ?)');
+  $insert->execute([$username, $email, $passwordHash]);
+  $userId = (int)$pdo->lastInsertId();
+} catch (Throwable $e) {
+  if ($e instanceof PDOException && $e->getCode() === '23000') {
+    $message = strtolower($e->getMessage());
+    http_response_code(409);
+    if (strpos($message, 'username') !== false) {
+      echo json_encode(['error' => 'username_already_used']);
+    } elseif (strpos($message, 'email') !== false) {
+      echo json_encode(['error' => 'email_already_used']);
+    } else {
+      echo json_encode(['error' => 'registration_conflict']);
+    }
+    exit;
+  }
+
+  http_response_code(500);
+  echo json_encode(['error' => 'registration_failed']);
+  exit;
+}
+
+$select = $pdo->prepare('SELECT id, username, email, active_team_id FROM users WHERE id=? LIMIT 1');
+$select->execute([$userId]);
+$user = $select->fetch();
+
+if (!$user) {
+  http_response_code(500);
+  echo json_encode(['error' => 'registration_failed']);
+  exit;
+}
+
+session_regenerate_id(true);
+$_SESSION['uid'] = (int)$user['id'];
+
+echo json_encode([
+  'id' => (int)$user['id'],
+  'username' => $user['username'] ?? null,
+  'email' => $user['email'] ?? null,
+  'active_team_id' => !empty($user['active_team_id']) ? (int)$user['active_team_id'] : null,
+]);

--- a/assets/app.js
+++ b/assets/app.js
@@ -320,12 +320,74 @@
       });
     }
 
+    function displayRegisterError(message) {
+      if (registerError) {
+        registerError.textContent = message;
+      }
+    }
+
     if (registerForm) {
-      registerForm.addEventListener('submit', (event) => {
+      registerForm.addEventListener('submit', async (event) => {
         event.preventDefault();
         if (registerError) {
-          registerError.textContent =
-            'La création de compte est gérée par un administrateur. Veuillez contacter le support.';
+          registerError.textContent = '';
+        }
+
+        const formData = new FormData(registerForm);
+        const username = (formData.get('username') || '').toString().trim();
+        const email = (formData.get('email') || '').toString().trim();
+        const password = (formData.get('password') || '').toString();
+        const confirmPassword = (formData.get('password-confirm') || '').toString();
+
+        if (!username || !email || !password || !confirmPassword) {
+          displayRegisterError('Veuillez renseigner tous les champs obligatoires.');
+          return;
+        }
+
+        if (password !== confirmPassword) {
+          displayRegisterError('Les mots de passe ne correspondent pas.');
+          return;
+        }
+
+        if (password.length < 6) {
+          displayRegisterError('Le mot de passe doit contenir au moins 6 caractères.');
+          return;
+        }
+
+        try {
+          const response = await fetch(`${API_BASE_URL}/register.php`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ username, email, password }),
+          });
+
+          if (!response.ok) {
+            let serverError =
+              response.status === 400
+                ? 'Veuillez vérifier les informations saisies.'
+                : 'Une erreur est survenue. Veuillez réessayer.';
+            try {
+              const payload = await response.json();
+              if (payload && typeof payload.error === 'string') {
+                serverError = traduireErreurInscription(payload.error);
+              }
+            } catch (parseError) {
+              // ignore JSON parsing errors
+            }
+            displayRegisterError(serverError);
+            return;
+          }
+
+          const payload = await response.json();
+          saveSessionUserInfo(payload);
+          saveActiveUser(payload.username);
+          await ensureRemoteVariablesLoaded(true);
+          registerForm.reset();
+          navigateToDashboard();
+        } catch (error) {
+          console.error('Impossible de créer le compte :', error);
+          displayRegisterError('Une erreur réseau est survenue. Veuillez réessayer.');
         }
       });
     }
@@ -14184,6 +14246,29 @@
         return 'Identifiants incorrects.';
       case 'db_connect_failed':
         return "Le service d'authentification est momentanément indisponible.";
+      default:
+        return 'Une erreur est survenue. Veuillez réessayer.';
+    }
+  }
+
+  function traduireErreurInscription(code) {
+    switch (code) {
+      case 'missing_fields':
+        return 'Veuillez renseigner tous les champs obligatoires.';
+      case 'invalid_username':
+        return "L'identifiant doit comporter entre 3 et 50 caractères et uniquement des lettres, chiffres ou ._-";
+      case 'invalid_email':
+        return "L'adresse mail renseignée n'est pas valide.";
+      case 'password_too_short':
+        return 'Le mot de passe doit contenir au moins 6 caractères.';
+      case 'email_already_used':
+        return 'Cette adresse mail est déjà associée à un compte UManager.';
+      case 'username_already_used':
+        return 'Cet identifiant est déjà utilisé. Veuillez en choisir un autre.';
+      case 'invalid_json':
+        return 'Les données envoyées sont invalides. Veuillez réessayer.';
+      case 'db_connect_failed':
+        return "Le service est momentanément indisponible.";
       default:
         return 'Une erreur est survenue. Veuillez réessayer.';
     }


### PR DESCRIPTION
## Summary
- add a PHP API endpoint that validates input, hashes passwords, and creates a session for new accounts
- update the registration form to call the API, perform client-side validation, and surface server errors to the user

## Testing
- php -l api/register.php

------
https://chatgpt.com/codex/tasks/task_e_69034be4a8dc8326b39616741246f051