### PR TITLE
Initialiser la base UManager (répertoire, recherche, mots-clés, import Excel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# UManager
+
+Base d'application web pour gérer un large répertoire de personnes avec :
+
+- Catégories ajoutables/éditables.
+- Champs obligatoires : **Nom de naissance**, **Prénom**, **Date de naissance**.
+- Génération d'un identifiant unique : `NOM_PRENOM_JJ_MM_AAAA`.
+- Recherche dynamique des contacts.
+- Gestion de mots-clés sur chaque contact.
+- Persistance en base de données locale SQLite (pas de cookies navigateur).
+- Import Excel avec mapping des colonnes vers les catégories du site.
+
+## Lancement
+
+```bash
+npm install
+npm start
+```
+
+Puis ouvrir : `http://localhost:3000`
+
+## Notes techniques
+
+- Base locale : `data/umanager.db`
+- API backend : Express + SQLite
+- Import Excel : package `xlsx`

--- a/db.js
+++ b/db.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const dbDir = path.join(__dirname, 'data');
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+const db = new sqlite3.Database(path.join(dbDir, 'umanager.db'));
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(this);
+      }
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows);
+      }
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(row);
+      }
+    });
+  });
+}
+
+async function initDb() {
+  await run('PRAGMA foreign_keys = ON');
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS categories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      code TEXT UNIQUE,
+      label TEXT NOT NULL,
+      required INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS people (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      unique_id TEXT NOT NULL UNIQUE,
+      last_name_birth TEXT NOT NULL,
+      first_name TEXT NOT NULL,
+      birth_date TEXT NOT NULL,
+      keywords_json TEXT DEFAULT '[]',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS person_category_values (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id INTEGER NOT NULL,
+      category_id INTEGER NOT NULL,
+      value TEXT,
+      FOREIGN KEY (person_id) REFERENCES people(id) ON DELETE CASCADE,
+      FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE,
+      UNIQUE(person_id, category_id)
+    )
+  `);
+
+  const requiredCategories = [
+    { code: 'last_name_birth', label: 'Nom de naissance' },
+    { code: 'first_name', label: 'Prénom' },
+    { code: 'birth_date', label: 'Date de naissance' }
+  ];
+
+  for (const category of requiredCategories) {
+    await run(
+      `INSERT OR IGNORE INTO categories (code, label, required) VALUES (?, ?, 1)`,
+      [category.code, category.label]
+    );
+  }
+}
+
+module.exports = {
+  db,
+  run,
+  all,
+  get,
+  initDb
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "umanager",
+  "version": "1.0.0",
+  "description": "Répertoire de personnes avec catégories dynamiques, recherche et import Excel",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "sqlite3": "^5.1.7",
+    "xlsx": "^0.18.5"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,289 @@
+let categories = [];
+let importHeaders = [];
+
+const categoriesList = document.getElementById('categories-list');
+const customFieldsContainer = document.getElementById('custom-fields');
+const peopleBody = document.getElementById('people-body');
+const personCreateResult = document.getElementById('person-create-result');
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Erreur API');
+  }
+
+  return response.json();
+}
+
+async function loadCategories() {
+  categories = await fetchJson('/api/categories');
+  renderCategories();
+  renderCustomFields();
+  renderImportMapping();
+}
+
+function renderCategories() {
+  categoriesList.innerHTML = '';
+
+  categories.forEach((category) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'category-item';
+
+    const left = document.createElement('div');
+    left.innerHTML = `<strong>${category.label}</strong>${
+      category.required ? '<span class="required">(obligatoire)</span>' : ''
+    }`;
+
+    const right = document.createElement('div');
+    const input = document.createElement('input');
+    input.value = category.label;
+    const save = document.createElement('button');
+    save.textContent = 'Éditer';
+    save.onclick = async () => {
+      try {
+        await fetchJson(`/api/categories/${category.id}`, {
+          method: 'PUT',
+          body: JSON.stringify({ label: input.value })
+        });
+        await loadCategories();
+      } catch (error) {
+        alert(error.message);
+      }
+    };
+
+    right.appendChild(input);
+    right.appendChild(save);
+
+    wrap.appendChild(left);
+    wrap.appendChild(right);
+    categoriesList.appendChild(wrap);
+  });
+}
+
+function renderCustomFields() {
+  customFieldsContainer.innerHTML = '';
+  const customCategories = categories.filter((c) => !c.required);
+
+  customCategories.forEach((category) => {
+    const label = document.createElement('label');
+    label.textContent = category.label;
+
+    const input = document.createElement('input');
+    input.id = `cat_${category.id}`;
+
+    label.appendChild(input);
+    customFieldsContainer.appendChild(label);
+  });
+}
+
+async function loadPeople(search = '') {
+  const url = new URL('/api/people', window.location.origin);
+  if (search.trim()) {
+    url.searchParams.set('search', search.trim());
+  }
+
+  const people = await fetchJson(url.toString());
+  peopleBody.innerHTML = '';
+
+  people.forEach((person) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${person.uniqueId}</td>
+      <td>${person.lastNameBirth}</td>
+      <td>${person.firstName}</td>
+      <td>${person.birthDate}</td>
+      <td>${person.keywords.join(', ')}</td>
+      <td>${person.customValues
+        .map((value) => `<div><strong>${value.categoryLabel}:</strong> ${value.value}</div>`)
+        .join('')}</td>
+    `;
+
+    peopleBody.appendChild(tr);
+  });
+}
+
+document.getElementById('add-category-form').addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const labelInput = document.getElementById('new-category-label');
+
+  try {
+    await fetchJson('/api/categories', {
+      method: 'POST',
+      body: JSON.stringify({ label: labelInput.value })
+    });
+    labelInput.value = '';
+    await loadCategories();
+  } catch (error) {
+    alert(error.message);
+  }
+});
+
+document.getElementById('person-form').addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const keywords = document
+    .getElementById('keywords')
+    .value.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean);
+
+  const customValues = {};
+  categories
+    .filter((c) => !c.required)
+    .forEach((category) => {
+      customValues[category.id] = document.getElementById(`cat_${category.id}`)?.value || '';
+    });
+
+  try {
+    const created = await fetchJson('/api/people', {
+      method: 'POST',
+      body: JSON.stringify({
+        lastNameBirth: document.getElementById('last_name_birth').value,
+        firstName: document.getElementById('first_name').value,
+        birthDate: document.getElementById('birth_date').value,
+        keywords,
+        customValues
+      })
+    });
+
+    personCreateResult.textContent = `Personne créée : ${created.unique_id}`;
+    document.getElementById('person-form').reset();
+    await loadPeople(document.getElementById('search-input').value);
+  } catch (error) {
+    personCreateResult.textContent = error.message;
+  }
+});
+
+let searchTimer = null;
+document.getElementById('search-input').addEventListener('input', (event) => {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => {
+    loadPeople(event.target.value).catch((error) => alert(error.message));
+  }, 200);
+});
+
+async function previewImport() {
+  const fileInput = document.getElementById('excel-file');
+  const file = fileInput.files[0];
+  if (!file) {
+    alert('Sélectionnez un fichier Excel.');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('excelFile', file);
+
+  const response = await fetch('/api/import/preview', {
+    method: 'POST',
+    body: formData
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || 'Erreur preview import');
+  }
+
+  importHeaders = data.headers;
+  renderImportMapping(data.sampleRows);
+}
+
+function mappingSelect(id, label, required = false) {
+  const requiredMark = required ? '*' : '';
+  const options = ['<option value="">-- choisir --</option>']
+    .concat(importHeaders.map((h) => `<option value="${h}">${h}</option>`))
+    .join('');
+
+  return `<label>${label}${requiredMark}<select id="${id}">${options}</select></label>`;
+}
+
+function renderImportMapping(sampleRows = null) {
+  const wrap = document.getElementById('import-mapping');
+
+  if (importHeaders.length === 0) {
+    wrap.innerHTML = '<p class="info">Analysez un fichier pour configurer le mapping.</p>';
+    return;
+  }
+
+  const customSelects = categories
+    .filter((c) => !c.required)
+    .map((c) => mappingSelect(`map_cat_${c.id}`, c.label))
+    .join('');
+
+  wrap.innerHTML = `
+    <h3>Mapping des colonnes</h3>
+    <div class="grid">
+      ${mappingSelect('map_last_name_birth', 'Nom de naissance', true)}
+      ${mappingSelect('map_first_name', 'Prénom', true)}
+      ${mappingSelect('map_birth_date', 'Date de naissance', true)}
+      ${mappingSelect('map_keywords', 'Mots-clés (optionnel)')}
+      ${customSelects}
+    </div>
+    ${
+      sampleRows
+        ? `<details><summary>Aperçu des lignes</summary><pre>${JSON.stringify(sampleRows, null, 2)}</pre></details>`
+        : ''
+    }
+  `;
+
+  document.getElementById('commit-import').hidden = false;
+}
+
+async function commitImport() {
+  const file = document.getElementById('excel-file').files[0];
+  if (!file) {
+    alert('Sélectionnez un fichier Excel.');
+    return;
+  }
+
+  const mapping = {
+    last_name_birth: document.getElementById('map_last_name_birth').value,
+    first_name: document.getElementById('map_first_name').value,
+    birth_date: document.getElementById('map_birth_date').value,
+    keywords: document.getElementById('map_keywords').value
+  };
+
+  if (!mapping.last_name_birth || !mapping.first_name || !mapping.birth_date) {
+    alert('Les mappings obligatoires doivent être renseignés.');
+    return;
+  }
+
+  categories
+    .filter((c) => !c.required)
+    .forEach((category) => {
+      mapping[`cat_${category.id}`] = document.getElementById(`map_cat_${category.id}`)?.value || '';
+    });
+
+  const formData = new FormData();
+  formData.append('excelFile', file);
+  formData.append('mapping', JSON.stringify(mapping));
+
+  const response = await fetch('/api/import/commit', {
+    method: 'POST',
+    body: formData
+  });
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || 'Erreur import');
+  }
+
+  document.getElementById('import-result').textContent = JSON.stringify(data, null, 2);
+  await loadPeople(document.getElementById('search-input').value);
+}
+
+document.getElementById('preview-import').addEventListener('click', () => {
+  previewImport().catch((error) => alert(error.message));
+});
+
+document.getElementById('commit-import').addEventListener('click', () => {
+  commitImport().catch((error) => alert(error.message));
+});
+
+(async function init() {
+  await loadCategories();
+  await loadPeople();
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UManager - Répertoire</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>UManager</h1>
+      <p>Répertoire de personnes avec catégories dynamiques et import Excel.</p>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>Catégories</h2>
+        <form id="add-category-form">
+          <input type="text" id="new-category-label" placeholder="Nouvelle catégorie" required />
+          <button type="submit">Ajouter</button>
+        </form>
+        <div id="categories-list"></div>
+      </section>
+
+      <section class="card">
+        <h2>Ajouter une personne</h2>
+        <form id="person-form">
+          <div class="grid">
+            <label>Nom de naissance* <input id="last_name_birth" required /></label>
+            <label>Prénom* <input id="first_name" required /></label>
+            <label>Date de naissance* <input id="birth_date" type="date" required /></label>
+            <label>Mots-clés (séparés par virgule) <input id="keywords" placeholder="client, premium" /></label>
+          </div>
+
+          <div id="custom-fields" class="grid"></div>
+          <button type="submit">Créer la personne</button>
+        </form>
+        <p class="info" id="person-create-result"></p>
+      </section>
+
+      <section class="card">
+        <h2>Import Excel</h2>
+        <div class="grid">
+          <label>Fichier Excel (.xlsx/.xls)
+            <input id="excel-file" type="file" accept=".xlsx,.xls" />
+          </label>
+          <button id="preview-import" type="button">1) Analyser le fichier</button>
+        </div>
+
+        <div id="import-mapping"></div>
+        <button id="commit-import" type="button" hidden>2) Importer</button>
+        <pre id="import-result" class="info"></pre>
+      </section>
+
+      <section class="card">
+        <h2>Contacts</h2>
+        <input id="search-input" placeholder="Recherche dynamique (nom, prénom, ID, mot-clé)" />
+        <table>
+          <thead>
+            <tr>
+              <th>ID Unique</th>
+              <th>Nom</th>
+              <th>Prénom</th>
+              <th>Date naissance</th>
+              <th>Mots-clés</th>
+              <th>Champs personnalisés</th>
+            </tr>
+          </thead>
+          <tbody id="people-body"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,91 @@
+:root {
+  font-family: Arial, sans-serif;
+  color: #1d2433;
+  background: #f4f7fb;
+}
+
+body {
+  margin: 0;
+}
+
+header {
+  background: #1f4c9c;
+  color: white;
+  padding: 1rem 2rem;
+}
+
+main {
+  max-width: 1200px;
+  margin: 1rem auto;
+  padding: 0 1rem 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 0.8rem;
+  margin-bottom: 0.8rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+input,
+button,
+select {
+  font-size: 14px;
+  padding: 0.55rem;
+}
+
+button {
+  cursor: pointer;
+  border: 1px solid #c3cde0;
+  border-radius: 6px;
+  background: #eef3ff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.8rem;
+}
+
+th,
+td {
+  border: 1px solid #dde4f2;
+  padding: 0.5rem;
+  vertical-align: top;
+  text-align: left;
+}
+
+.info {
+  color: #1f4c9c;
+}
+
+.category-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #dde4f2;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.required {
+  font-size: 12px;
+  color: #6a7ca6;
+  margin-left: 0.5rem;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,333 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const multer = require('multer');
+const XLSX = require('xlsx');
+const { initDb, all, get, run } = require('./db');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const uploadDir = path.join(__dirname, 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const upload = multer({ dest: uploadDir });
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+function normalizeForId(value) {
+  return (value || '')
+    .toString()
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '')
+    .toUpperCase();
+}
+
+function formatDatePart(dateInput) {
+  const date = new Date(dateInput);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Date invalide: ${dateInput}`);
+  }
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  return {
+    iso: `${year}-${month}-${day}`,
+    part: `${day}_${month}_${year}`
+  };
+}
+
+function buildUniqueId(lastNameBirth, firstName, birthDate) {
+  const last = normalizeForId(lastNameBirth);
+  const first = normalizeForId(firstName);
+  const datePart = formatDatePart(birthDate).part;
+  return `${last}_${first}_${datePart}`;
+}
+
+async function listPeople(search = '') {
+  const like = `%${search.trim()}%`;
+  const people = await all(
+    `
+      SELECT *
+      FROM people
+      WHERE ? = ''
+         OR unique_id LIKE ?
+         OR last_name_birth LIKE ?
+         OR first_name LIKE ?
+         OR keywords_json LIKE ?
+      ORDER BY last_name_birth COLLATE NOCASE, first_name COLLATE NOCASE
+    `,
+    [search.trim(), like, like, like, like]
+  );
+
+  const categoryValues = await all(`
+    SELECT pcv.person_id, c.id AS category_id, c.label AS category_label, pcv.value
+    FROM person_category_values pcv
+    JOIN categories c ON c.id = pcv.category_id
+  `);
+
+  const groupedValues = categoryValues.reduce((acc, row) => {
+    if (!acc[row.person_id]) {
+      acc[row.person_id] = [];
+    }
+    acc[row.person_id].push({
+      categoryId: row.category_id,
+      categoryLabel: row.category_label,
+      value: row.value
+    });
+    return acc;
+  }, {});
+
+  return people.map((person) => ({
+    id: person.id,
+    uniqueId: person.unique_id,
+    lastNameBirth: person.last_name_birth,
+    firstName: person.first_name,
+    birthDate: person.birth_date,
+    keywords: JSON.parse(person.keywords_json || '[]'),
+    customValues: groupedValues[person.id] || []
+  }));
+}
+
+app.get('/api/categories', async (_req, res) => {
+  try {
+    const categories = await all(`SELECT * FROM categories ORDER BY required DESC, label COLLATE NOCASE`);
+    res.json(categories);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.post('/api/categories', async (req, res) => {
+  const { label } = req.body;
+  if (!label || !label.trim()) {
+    return res.status(400).json({ error: 'Le nom de catégorie est obligatoire.' });
+  }
+  try {
+    const result = await run(
+      `INSERT INTO categories (code, label, required) VALUES (?, ?, 0)`,
+      [null, label.trim()]
+    );
+    const category = await get(`SELECT * FROM categories WHERE id = ?`, [result.lastID]);
+    return res.status(201).json(category);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+app.put('/api/categories/:id', async (req, res) => {
+  const { label } = req.body;
+  if (!label || !label.trim()) {
+    return res.status(400).json({ error: 'Le nom de catégorie est obligatoire.' });
+  }
+  try {
+    await run(`UPDATE categories SET label = ? WHERE id = ?`, [label.trim(), req.params.id]);
+    const category = await get(`SELECT * FROM categories WHERE id = ?`, [req.params.id]);
+    return res.json(category);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+app.post('/api/people', async (req, res) => {
+  const {
+    lastNameBirth,
+    firstName,
+    birthDate,
+    keywords = [],
+    customValues = {}
+  } = req.body;
+
+  if (!lastNameBirth || !firstName || !birthDate) {
+    return res.status(400).json({
+      error: 'Nom de naissance, prénom et date de naissance sont obligatoires.'
+    });
+  }
+
+  try {
+    const { iso } = formatDatePart(birthDate);
+    const uniqueId = buildUniqueId(lastNameBirth, firstName, iso);
+    const insertPerson = await run(
+      `
+      INSERT INTO people (unique_id, last_name_birth, first_name, birth_date, keywords_json)
+      VALUES (?, ?, ?, ?, ?)
+    `,
+      [
+        uniqueId,
+        lastNameBirth.trim(),
+        firstName.trim(),
+        iso,
+        JSON.stringify(
+          Array.isArray(keywords)
+            ? keywords.map((k) => k.toString().trim()).filter(Boolean)
+            : []
+        )
+      ]
+    );
+
+    const personId = insertPerson.lastID;
+    const categories = await all(`SELECT id FROM categories WHERE required = 0`);
+    for (const category of categories) {
+      const value = customValues[category.id] ?? customValues[String(category.id)] ?? '';
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        await run(
+          `INSERT INTO person_category_values (person_id, category_id, value) VALUES (?, ?, ?)`,
+          [personId, category.id, String(value).trim()]
+        );
+      }
+    }
+
+    const person = await get(`SELECT * FROM people WHERE id = ?`, [personId]);
+    return res.status(201).json(person);
+  } catch (error) {
+    if (error.message.includes('UNIQUE constraint failed: people.unique_id')) {
+      return res.status(409).json({
+        error: "Une personne avec cet identifiant unique existe déjà."
+      });
+    }
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+app.get('/api/people', async (req, res) => {
+  try {
+    const people = await listPeople(req.query.search || '');
+    return res.json(people);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+app.post('/api/import/preview', upload.single('excelFile'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Fichier Excel manquant.' });
+  }
+
+  try {
+    const workbook = XLSX.readFile(req.file.path);
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+    const headers = rows.length > 0 ? Object.keys(rows[0]) : [];
+
+    return res.json({
+      headers,
+      sampleRows: rows.slice(0, 5)
+    });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  } finally {
+    fs.unlink(req.file.path, () => {});
+  }
+});
+
+app.post('/api/import/commit', upload.single('excelFile'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Fichier Excel manquant.' });
+  }
+
+  const mapping = req.body.mapping ? JSON.parse(req.body.mapping) : null;
+  if (!mapping) {
+    return res.status(400).json({ error: 'Le mapping des colonnes est obligatoire.' });
+  }
+
+  try {
+    const workbook = XLSX.readFile(req.file.path);
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+
+    const categories = await all(`SELECT id, required, code FROM categories`);
+    const customCategories = categories.filter((c) => c.required === 0);
+
+    await run('BEGIN TRANSACTION');
+    let imported = 0;
+    const skipped = [];
+
+    for (let i = 0; i < rows.length; i += 1) {
+      const row = rows[i];
+      const lastNameBirth = row[mapping.last_name_birth] ?? '';
+      const firstName = row[mapping.first_name] ?? '';
+      const birthDateRaw = row[mapping.birth_date] ?? '';
+      const keywordsRaw = mapping.keywords ? row[mapping.keywords] : '';
+
+      if (!lastNameBirth || !firstName || !birthDateRaw) {
+        skipped.push({ row: i + 2, reason: 'Champs obligatoires manquants' });
+        continue;
+      }
+
+      let isoDate;
+      try {
+        isoDate = formatDatePart(birthDateRaw).iso;
+      } catch {
+        skipped.push({ row: i + 2, reason: 'Date invalide' });
+        continue;
+      }
+
+      const uniqueId = buildUniqueId(lastNameBirth, firstName, isoDate);
+      try {
+        const insertPerson = await run(
+          `
+            INSERT INTO people (unique_id, last_name_birth, first_name, birth_date, keywords_json)
+            VALUES (?, ?, ?, ?, ?)
+          `,
+          [
+            uniqueId,
+            String(lastNameBirth).trim(),
+            String(firstName).trim(),
+            isoDate,
+            JSON.stringify(
+              String(keywordsRaw)
+                .split(',')
+                .map((k) => k.trim())
+                .filter(Boolean)
+            )
+          ]
+        );
+
+        for (const category of customCategories) {
+          const mapKey = `cat_${category.id}`;
+          const columnName = mapping[mapKey];
+          if (!columnName) continue;
+          const value = row[columnName];
+          if (value === undefined || value === null || String(value).trim() === '') continue;
+
+          await run(
+            `INSERT INTO person_category_values (person_id, category_id, value) VALUES (?, ?, ?)`,
+            [insertPerson.lastID, category.id, String(value).trim()]
+          );
+        }
+
+        imported += 1;
+      } catch {
+        skipped.push({ row: i + 2, reason: `Doublon identifiant (${uniqueId})` });
+      }
+    }
+
+    await run('COMMIT');
+
+    return res.json({ imported, skipped });
+  } catch (error) {
+    await run('ROLLBACK');
+    return res.status(500).json({ error: error.message });
+  } finally {
+    fs.unlink(req.file.path, () => {});
+  }
+});
+
+initDb()
+  .then(() => {
+    app.listen(PORT, () => {
+      // eslint-disable-next-line no-console
+      console.log(`UManager lancé sur http://localhost:${PORT}`);
+    });
+  })
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Erreur init DB:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Motivation
- Fournir une base minimale d'une application web de gestion de répertoire avec persistance locale (SQLite) et sans utilisation des cookies pour stocker les données.  
- Supporter des catégories dynamiques et trois champs obligatoires (`Nom de naissance`, `Prénom`, `Date de naissance`) avec génération d'un identifiant unique au format `NOM_PRENOM_JJ_MM_AAAA`.  
- Permettre une recherche dynamique côté interface et la gestion de mots-clés par contact.  
- Offrir un import Excel performant en deux étapes (prévisualisation + mapping puis import transactionnel) pour peupler rapidement le répertoire.

### Description
- Ajout du schéma et de l'initialisation SQLite dans `db.js` avec les tables `categories`, `people` et `person_category_values` et insertion des 3 catégories obligatoires.  
- Implémentation d'un backend Express dans `server.js` exposant les API REST pour gérer les catégories (`GET/POST/PUT /api/categories`), les personnes (`POST/GET /api/people`), et l'import Excel (`POST /api/import/preview`, `POST /api/import/commit`).  
- Logique de génération d'identifiant unique et normalisation des noms via `buildUniqueId`, `normalizeForId` et `formatDatePart` pour obtenir `NOM_PRENOM_JJ_MM_AAAA`.  
- Frontend basique ajouté dans `public/` (`index.html`, `app.js`, `styles.css`) fournissant l'UI pour créer/éditer catégories, créer une personne (avec champs personnalisés et mots-clés), recherche dynamique et workflow d'import avec mapping des colonnes.

### Testing
- Tentative d'installation des dépendances avec `npm install` a échoué en environnement CI avec une erreur réseau/politique (`403 Forbidden` depuis le registre npm), donc l'exécution runtime de l'application n'a pas été possible ici.  
- Contrôles git: ajout et commit des fichiers (`git add` + `git commit`) et inspection du dernier commit via `git log -1 --stat --oneline` ont réussi.  
- Aucun test automatisé unitaire n'a été exécuté dans cet environnement; il est recommandé de lancer `npm install` puis `npm start` localement pour valider le comportement et de couvrir ensuite les routes critiques par des tests d'intégration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9eda32b48326994cdccdff99a054)